### PR TITLE
Expanding vanilla prices

### DIFF
--- a/tf_quant_finance/black_scholes/BUILD
+++ b/tf_quant_finance/black_scholes/BUILD
@@ -25,7 +25,8 @@ py_library(
     srcs_version = "PY3",
     deps = [
         # tensorflow dep,
-    ],
+        # numpy dep,
+  ],
 )
 
 py_test(

--- a/tf_quant_finance/black_scholes/vanilla_prices.py
+++ b/tf_quant_finance/black_scholes/vanilla_prices.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Black Scholes prices of a batch of European options."""
 
+import numpy as np
 import tensorflow.compat.v2 as tf
 
 
@@ -22,6 +23,9 @@ def option_price(*,
                  expiries,
                  spots=None,
                  forwards=None,
+                 discount_rates=None,
+                 continuous_dividends=None,
+                 cost_of_carries=None,
                  discount_factors=None,
                  is_call_options=None,
                  dtype=None,
@@ -64,21 +68,45 @@ def option_price(*,
     forwards: A real `Tensor` of any shape that broadcasts to the shape of
       `volatilities`. The forwards to maturity. Either this argument or the
       `spots` must be supplied but both must not be supplied.
+    discount_rates: An optional real `Tensor` of same dtype as the
+      `volatilities` and of the shape that broadcasts with `volatilities`.
+      If not `None`, discount factors are calculated as e^(-rT),
+      where r are the discount rates, or risk free rates. At most one of
+      discount_rates and discount_factors can be supplied.
+      Default value: `None`, equivalent to r = 0 and discount factors = 1 when
+      discount_factors also not given.
+    continuous_dividends: An optional real `Tensor` of same dtype as the
+      `volatilities` and of the shape that broadcasts with `volatilities`.
+      If not `None`, `cost_of_carries` is calculated as r - q,
+      where r are the `discount_rates` and q is `continuous_dividends`. Either
+      this or `cost_of_carries` can be given.
+      Default value: `None`, equivalent to q = 0.
+    cost_of_carries: An optional real `Tensor` of same dtype as the
+      `volatilities` and of the shape that broadcasts with `volatilities`.
+      Cost of storing a physical commodity, the cost of interest paid when
+      long, or the opportunity cost, or the cost of paying dividends when short.
+      If not `None`, and `spots` is supplied, used to calculate forwards from
+      spots: F = e^(bT) * S, where F is the forwards price, b is the cost of
+      carries, T is expiries and S is the spot price. If `None`, value assumed
+      to be equal to the `discount_rate` - `continuous_dividends`
+      Default value: `None`, equivalent to b = r.
     discount_factors: An optional real `Tensor` of same dtype as the
-      `volatilities`. If not None, these are the discount factors to expiry
-      (i.e. e^(-rT)). If None, no discounting is applied (i.e. the undiscounted
+      `volatilities`. If not `None`, these are the discount factors to expiry
+      (i.e. e^(-rT)). Mutually exclusive with discount_rate and cost_of_carry.
+      If neither is given, no discounting is applied (i.e. the undiscounted
       option price is returned). If `spots` is supplied and `discount_factors`
-      is not None then this is also used to compute the forwards to expiry.
-      Default value: None, equivalent to discount factors = 1.
+      is not `None` then this is also used to compute the forwards to expiry.
+      At most one of discount_rates and discount_factors can be supplied.
+      Default value: `None`, which maps to -log(discount_factors) / expiries
     is_call_options: A boolean `Tensor` of a shape compatible with
       `volatilities`. Indicates whether the option is a call (if True) or a put
       (if False). If not supplied, call options are assumed.
     dtype: Optional `tf.DType`. If supplied, the dtype to be used for conversion
       of any supplied non-`Tensor` arguments to `Tensor`.
-      Default value: None which maps to the default dtype inferred by TensorFlow
+      Default value: `None` which maps to the default dtype inferred by TensorFlow
         (float32).
     name: str. The name for the ops created by this function.
-      Default value: None which is mapped to the default name `option_price`.
+      Default value: `None` which is mapped to the default name `option_price`.
 
   Returns:
     option_prices: A `Tensor` of the same shape as `forwards`. The Black
@@ -87,9 +115,18 @@ def option_price(*,
   Raises:
     ValueError: If both `forwards` and `spots` are supplied or if neither is
       supplied.
+    ValueError: If both `discount_rates` and `discount_factors` is supplied.
+    ValueError: If both `continuous_dividends` and `cost_of_carries` is
+      supplied.
   """
   if (spots is None) == (forwards is None):
     raise ValueError('Either spots or forwards must be supplied but not both.')
+  if (discount_rates is not None) and (discount_factors is not None):
+    raise ValueError('At most one of discount_rates and discount_factors may '
+                     'be supplied')
+  if (continuous_dividends is not None) and (cost_of_carries is not None):
+    raise ValueError('At most one of continuous_dividends and cost_of_carries '
+                     'may be supplied')
 
   with tf.name_scope(name or 'option_price'):
     strikes = tf.convert_to_tensor(strikes, dtype=dtype, name='strikes')
@@ -98,22 +135,41 @@ def option_price(*,
         volatilities, dtype=dtype, name='volatilities')
     expiries = tf.convert_to_tensor(expiries, dtype=dtype, name='expiries')
 
-    if discount_factors is None:
-      discount_factors = tf.convert_to_tensor(
-          1.0, dtype=dtype, name='discount_factors')
+    if discount_rates is not None:
+      discount_rates = tf.convert_to_tensor(
+          discount_rates, dtype=dtype, name='discount_rates')
+    elif discount_factors is not None:
+      discount_rates = -tf.math.log(discount_factors) / expiries
     else:
+      discount_rates = tf.convert_to_tensor(
+          0.0, dtype=dtype, name='discount_rates')
+
+    if continuous_dividends is None:
+      continuous_dividends = tf.convert_to_tensor(
+          0.0, dtype=dtype, name='continuous_dividends')
+
+    if cost_of_carries is not None:
+      cost_of_carries = tf.convert_to_tensor(
+          cost_of_carries, dtype=dtype, name='cost_of_carries')
+    else:
+      cost_of_carries = discount_rates - continuous_dividends
+
+    if discount_factors is not None:
       discount_factors = tf.convert_to_tensor(
           discount_factors, dtype=dtype, name='discount_factors')
+    else:
+      discount_factors = tf.exp(-discount_rates * expiries)
 
     if forwards is not None:
       forwards = tf.convert_to_tensor(forwards, dtype=dtype, name='forwards')
     else:
       spots = tf.convert_to_tensor(spots, dtype=dtype, name='spots')
-      forwards = spots / discount_factors
+      forwards = spots * tf.exp(cost_of_carries * expiries)
 
-    sqrt_var = volatilities * tf.math.sqrt(expiries)
-    d1 = (tf.math.log(forwards / strikes) + sqrt_var * sqrt_var / 2) / sqrt_var
-    d2 = d1 - sqrt_var
+    total_var = volatilities * tf.math.sqrt(expiries)
+    d1 = (
+      tf.math.log(forwards / strikes) + total_var * total_var / 2) / total_var
+    d2 = d1 - total_var
     undiscounted_calls = forwards * _ncdf(d1) - strikes * _ncdf(d2)
     if is_call_options is None:
       return discount_factors * undiscounted_calls
@@ -245,4 +301,4 @@ def _ncdf(x):
   return (tf.math.erf(x / _SQRT_2) + 1) / 2
 
 
-_SQRT_2 = 1.4142135623730951
+_SQRT_2 = np.sqrt(2. , dtype=np.float64)

--- a/tf_quant_finance/black_scholes/vanilla_prices_test.py
+++ b/tf_quant_finance/black_scholes/vanilla_prices_test.py
@@ -16,6 +16,7 @@
 
 """Tests for vanilla_price."""
 
+from absl.testing import parameterized
 import numpy as np
 import tensorflow.compat.v2 as tf
 import tensorflow_probability as tfp
@@ -25,7 +26,7 @@ from tensorflow.python.framework import test_util  # pylint: disable=g-direct-te
 
 
 @test_util.run_all_in_graph_and_eager_modes
-class VanillaPrice(tf.test.TestCase):
+class VanillaPrice(tf.test.TestCase, parameterized.TestCase):
   """Tests for methods for the vanilla pricing module."""
 
   def test_option_prices(self):
@@ -133,6 +134,39 @@ class VanillaPrice(tf.test.TestCase):
             expiries=expiries / scaling / scaling,
             forwards=forwards))
     self.assertArrayNear(base_prices, scaled_prices, 1e-10)
+
+  @parameterized.named_parameters(
+    {
+      'testcase_name': 'SinglePrecision',
+      'dtype': np.float32
+    }, {
+      'testcase_name': 'DoublePrecision',
+      'dtype': np.float64
+    })
+  def test_option_prices_detailed_discount(self, dtype):
+    """Tests that the prices are when giving risk_free_rates and
+    cost_of_carries."""
+    spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
+    strikes = np.array([100.0] * 10)
+    risk_free_rates = 0.08
+    volatilities = 0.2
+    expiries = 0.25
+
+    is_call_options = np.array([True] * 5 + [False] * 5)
+    cost_of_carries = -0.04
+    computed_prices = self.evaluate(
+      tff.black_scholes.option_price(
+        volatilities=volatilities,
+        strikes=strikes,
+        expiries=expiries,
+        spots=spots,
+        discount_rates=risk_free_rates,
+        cost_of_carries=cost_of_carries,
+        is_call_options=is_call_options,
+        dtype=dtype))
+    expected_prices = np.array([0.03, 0.57, 3.42, 9.85, 18.62, 20.41, 11.25,
+                                4.40, 1.12, 0.18])
+    self.assertArrayNear(expected_prices, computed_prices, 5e-3)
 
   def test_binary_prices(self):
     """Tests that the BS binary option prices are correct."""


### PR DESCRIPTION
Editing vanilla prices to take in cost_of_carries and discount_rates and continuous dividend while keeping compatibility with version that takes in discount_factors.