### PR TITLE
Explain class: SwapCurveBuilderResult

### DIFF
--- a/api_docs/tf_quant_finance/rates.md
+++ b/api_docs/tf_quant_finance/rates.md
@@ -37,7 +37,7 @@ Functions to handle rates.
 
 ## Classes
 
-[`class SwapCurveBuilderResult`](../tf_quant_finance/rates/SwapCurveBuilderResult.md): SwapCurveBuilderResult(times, rates, discount_factors, initial_rates, converged, failed, iterations, objective_value)
+[`class SwapCurveBuilderResult`](../tf_quant_finance/rates/SwapCurveBuilderResult.md): Build curves for swapping future cash flows.
 
 ## Functions
 


### PR DESCRIPTION
Remove definition of class attributes, which are already detailed in the docs: SwapCurveBuilderResult.md. Instead, explain the use of the class using a similar convention found under other Class headers in the docs.