### PR TITLE
Standardize dividend argument in option models

### DIFF
--- a/tf_quant_finance/black_scholes/approximations/american_option.py
+++ b/tf_quant_finance/black_scholes/approximations/american_option.py
@@ -90,6 +90,8 @@ def adesi_whaley(*,
       `volatilities`. The continuous dividend rate on the underliers. May be
       negative (to indicate costs of holding the underlier).
       Default value: `None`, equivalent to zero dividends.
+    continuous_dividends: `Tensor` equivalent to `dividend_rates`, to be            
+      deprecated.
     discount_factors: An optional real `Tensor` of same dtype as the
       `volatilities`. If not `None`, these are the discount factors to expiry
       (i.e. e^(-rT)). Mutually exclusive with discount_rate.

--- a/tf_quant_finance/black_scholes/approximations/american_option.py
+++ b/tf_quant_finance/black_scholes/approximations/american_option.py
@@ -20,8 +20,10 @@ import tensorflow.compat.v2 as tf
 from tf_quant_finance.black_scholes import vanilla_prices
 from tf_quant_finance.math import gradient
 from tf_quant_finance.math.root_search import newton as root_finder_newton
+from tensorflow.python.util import deprecation
 
 
+@deprecation.deprecated_args(None, "continuous_dividends is deprecated. Use dividend_rates instead", "continuous_dividends")
 def adesi_whaley(*,
                  volatilities,
                  strikes,
@@ -30,6 +32,7 @@ def adesi_whaley(*,
                  forwards=None,
                  discount_rates=None,
                  continuous_dividends=None,
+                 dividend_rates=None,
                  discount_factors=None,
                  is_call_options=None,
                  max_iterations=100,
@@ -52,7 +55,7 @@ def adesi_whaley(*,
       strikes=strikes,
       expiries=expiries,
       discount_rates=discount_rates,
-      continuous_dividends=continuous_dividends,
+      dividend_rates=dividends,
       spots=spots,
       dtype=tf.float64)
   # Expected print output of computed prices:
@@ -83,7 +86,7 @@ def adesi_whaley(*,
       where r are the discount rates, or risk free rates.
       Default value: `None`, equivalent to r = 0 and discount factors = 1 when
       discount_factors also not given.
-    continuous_dividends: An optional real `Tensor` of same dtype as the
+    dividend_rates: An optional real `Tensor` of same dtype as the
       `volatilities`. The continuous dividend rate on the underliers. May be
       negative (to indicate costs of holding the underlier).
       Default value: `None`, equivalent to zero dividends.
@@ -137,6 +140,7 @@ def adesi_whaley(*,
     ValueError:
       (a) If both `forwards` and `spots` are supplied or if neither is supplied.
   """
+  dividend_rates = deprecation.deprecated_argument_lookup("dividend_rates", dividend_rates, "continuous_dividends", continuous_dividends)
   if (spots is None) == (forwards is None):
     raise ValueError("Either spots or forwards must be supplied but not both.")
   if (discount_rates is not None) and (discount_factors is not None):
@@ -158,16 +162,16 @@ def adesi_whaley(*,
     else:
       discount_rates = tf.constant(0.0, dtype=dtype, name="discount_rates")
 
-    if continuous_dividends is not None:
-      continuous_dividends = tf.convert_to_tensor(
-          continuous_dividends, dtype=dtype, name="continuous_dividends")
+    if dividend_rates is not None:
+      dividend_rates = tf.convert_to_tensor(
+          dividend_rates, dtype=dtype, name="dividend_rates")
     else:
-      continuous_dividends = 0
+      dividend_rates = 0
     # Set forwards and spots
     if forwards is not None:
       spots = tf.convert_to_tensor(
           forwards *
-          tf.exp(-(discount_rates - continuous_dividends) * expiries),
+          tf.exp(-(discount_rates - dividend_rates) * expiries),
           dtype=dtype,
           name="spots")
     else:
@@ -184,7 +188,7 @@ def adesi_whaley(*,
         t=expiries,
         s=spots,
         r=discount_rates,
-        d=continuous_dividends,
+        d=dividend_rates,
         is_call_options=is_call_options,
         dtype=dtype,
         max_iterations=max_iterations,
@@ -202,10 +206,10 @@ def adesi_whaley(*,
         expiries=expiries,
         spots=spots,
         discount_rates=discount_rates,
-        continuous_dividends=continuous_dividends,
+        dividend_rates=dividend_rates,
         dtype=dtype,
         name=name)
-    calculate_eu = is_call_options & (continuous_dividends <= 0)
+    calculate_eu = is_call_options & (dividend_rates <= 0)
     converged = tf.where(calculate_eu, True, converged)
     failed = tf.where(calculate_eu, False, failed)
     return tf.where(calculate_eu, eu_prices, am_prices), converged, failed
@@ -242,7 +246,7 @@ def _adesi_whaley(*, sigma, x, t, r, d, s, is_call_options, max_iterations,
       expiries=t,
       spots=s,
       discount_rates=r,
-      continuous_dividends=d,
+      dividend_rates=d,
       is_call_options=is_call_options,
       dtype=dtype)
 
@@ -287,7 +291,7 @@ def _adesi_whaley_critical_values(*,
         expiries=t,
         spots=s_crit,
         discount_rates=r,
-        continuous_dividends=d,
+        dividend_rates=d,
         is_call_options=is_call_options,
         dtype=dtype) + sign *
             (1 - tf.math.exp(-d * t) *

--- a/tf_quant_finance/black_scholes/approximations/american_option_test.py
+++ b/tf_quant_finance/black_scholes/approximations/american_option_test.py
@@ -50,7 +50,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
         strikes=strikes,
         expiries=expiries,
         discount_rates=discount_rates,
-        continuous_dividends=dividends,
+        dividend_rates=dividends,
         is_call_options=is_call_options,
         spots=spots,
         dtype=tf.float64)
@@ -84,7 +84,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
         strikes=strikes,
         expiries=expiries,
         discount_rates=discount_rates,
-        continuous_dividends=dividends,
+        dividend_rates=dividends,
         spots=spots,
         is_call_options=is_call_options,
         dtype=tf.float64)
@@ -121,7 +121,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
         strikes=strikes,
         expiries=expiries,
         discount_rates=discount_rates,
-        continuous_dividends=dividends,
+        dividend_rates=dividends,
         forwards=forwards,
         is_call_options=is_call_options,
         dtype=tf.float64)

--- a/tf_quant_finance/black_scholes/vanilla_prices.py
+++ b/tf_quant_finance/black_scholes/vanilla_prices.py
@@ -88,6 +88,8 @@ def option_price(*,
       where r are the `discount_rates` and q is `dividend_rates`. Either
       this or `cost_of_carries` can be given.
       Default value: `None`, equivalent to q = 0.
+    continuous_dividends: `Tensor` equivalent to `dividend_rates`, to be
+      deprecated.
     cost_of_carries: An optional real `Tensor` of same dtype as the
       `volatilities` and of the shape that broadcasts with `volatilities`.
       Cost of storing a physical commodity, the cost of interest paid when
@@ -290,6 +292,8 @@ def barrier_price(*,
       continuous dividend rate paid by the underlier. If `None`, then
       defaults to zero dividends.
       Default value: `None`, equivalent to zero dividends.
+    continuous_dividends: `Tensor` equivalent to `dividend_rates`, to be            
+      deprecated.
     cost_of_carries: A optional real `Tensor` of same dtype as the
       `volatilities` and of the shape that broadcasts with `volatilities`.
       Cost of storing a physical commodity, the cost of interest paid when
@@ -679,6 +683,8 @@ def asset_or_nothing_price(*,
       `discount_rates` and q is `dividend_rates`. Either this or
       `cost_of_carries` can be given.
       Default value: `None`, equivalent to q = 0.
+    continuous_dividends: `Tensor` equivalent to `dividend_rates`, to be            
+      deprecated.
     cost_of_carries: An optional real `Tensor` of same dtype as the
       `volatilities` and of the shape that broadcasts with `volatilities`. Cost
       of storing a physical commodity, the cost of interest paid when long, or

--- a/tf_quant_finance/black_scholes/vanilla_prices_test.py
+++ b/tf_quant_finance/black_scholes/vanilla_prices_test.py
@@ -560,7 +560,7 @@ class VanillaPrice(parameterized.TestCase, tf.test.TestCase):
           'expiries': 0.5,
           'spots': 100.0,
           'discount_rates': 0.08,
-          'continuous_dividends': 0.04,
+          'dividend_rates': 0.04,
           'barriers': 105.0,
           'rebates': 3.0,
           'is_barrier_down': False,
@@ -574,7 +574,7 @@ class VanillaPrice(parameterized.TestCase, tf.test.TestCase):
           'expiries': 10.0,
           'spots': 100.0,
           'discount_rates': None,
-          'continuous_dividends': None,
+          'dividend_rates': None,
           'barriers': 90.0,
           'rebates': None,
           'is_barrier_down': True,
@@ -589,7 +589,7 @@ class VanillaPrice(parameterized.TestCase, tf.test.TestCase):
           'expiries': [.5, .5, .5, .5, .5, .5, .5, .5],
           'spots': [100., 100., 100., 100., 100., 100., 100., 100.],
           'discount_rates': [.08, .08, .08, .08, .08, .08, .08, .08],
-          'continuous_dividends': [.04, .04, .04, .04, .04, .04, .04, .04],
+          'dividend_rates': [.04, .04, .04, .04, .04, .04, .04, .04],
           'barriers': [95., 95., 105., 105., 95., 105., 95., 105.],
           'rebates': [3., 3., 3., 3., 3., 3., 3., 3.],
           'is_barrier_down':
@@ -607,7 +607,7 @@ class VanillaPrice(parameterized.TestCase, tf.test.TestCase):
           'expiries': [[.5, .5], [.5, .5], [.5, .5], [.5, .5]],
           'spots': [[100., 100.], [100., 100.], [100., 100.], [100., 100.]],
           'discount_rates': [[.08, .08], [.08, .08], [.08, .08], [.08, .08]],
-          'continuous_dividends': [[.04, .04], [.04, .04], [.04, .04],
+          'dividend_rates': [[.04, .04], [.04, .04], [.04, .04],
                                    [.04, .04]],
           'barriers': [[95., 95.], [105., 105.], [95., 105.], [95., 105.]],
           'rebates': [[3., 3.], [3., 3.], [3., 3.], [3., 3.]],
@@ -647,7 +647,7 @@ class VanillaPrice(parameterized.TestCase, tf.test.TestCase):
                           is_knock_out,
                           is_call_options,
                           expected_price,
-                          continuous_dividends=None,
+                          dividend_rates=None,
                           cost_of_carries=None):
     """Computes test barrier option prices for the parameterized inputs."""
     # The input values are from examples in the following textbook:
@@ -660,7 +660,7 @@ class VanillaPrice(parameterized.TestCase, tf.test.TestCase):
           spots=spots,
           discount_rates=discount_rates,
           cost_of_carries=cost_of_carries,
-          continuous_dividends=continuous_dividends,
+          dividend_rates=dividend_rates,
           barriers=barriers,
           rebates=rebates,
           is_barrier_down=is_barrier_down,
@@ -673,7 +673,7 @@ class VanillaPrice(parameterized.TestCase, tf.test.TestCase):
           expiries=expiries,
           spots=spots,
           discount_rates=discount_rates,
-          continuous_dividends=continuous_dividends,
+          dividend_rates=dividend_rates,
           barriers=barriers,
           rebates=rebates,
           is_barrier_down=is_barrier_down,
@@ -726,7 +726,7 @@ class VanillaPrice(parameterized.TestCase, tf.test.TestCase):
     rebates = tf.convert_to_tensor(3.0, dtype=dtype)
     expiries = tf.convert_to_tensor(0.5, dtype=dtype)
     discount_rates = tf.convert_to_tensor(0.08, dtype=dtype)
-    continuous_dividends = tf.convert_to_tensor(0.04, dtype=dtype)
+    dividend_rates = tf.convert_to_tensor(0.04, dtype=dtype)
     strikes = tf.convert_to_tensor(90.0, dtype=dtype)
     barriers = tf.convert_to_tensor(95.0, dtype=dtype)
     expected_price = tf.convert_to_tensor(9.0246, dtype=dtype)
@@ -742,7 +742,7 @@ class VanillaPrice(parameterized.TestCase, tf.test.TestCase):
           expiries=samples[2],
           spots=samples[3],
           discount_rates=samples[3],
-          continuous_dividends=samples[4],
+          dividend_rates=samples[4],
           barriers=samples[5],
           rebates=samples[6],
           is_barrier_down=samples[7],
@@ -755,7 +755,7 @@ class VanillaPrice(parameterized.TestCase, tf.test.TestCase):
 
     price = xla_compiled_op([
         volatilities, strikes, expiries, spots, discount_rates,
-        continuous_dividends, barriers, rebates, is_barrier_down, is_knock_out,
+        dividend_rates, barriers, rebates, is_barrier_down, is_knock_out,
         is_call_options
     ])
     self.assertAllClose(price, expected_price, 10e-3)

--- a/tf_quant_finance/experimental/local_volatility/local_volatility_model.py
+++ b/tf_quant_finance/experimental/local_volatility/local_volatility_model.py
@@ -75,7 +75,7 @@ def _dupire_local_volatility(time, spot_price, initial_spot_price,
         strikes=strike,
         expiries=expiry_time,
         spots=initial_spot_price,
-        continuous_dividends=dividend_yield,
+        dividend_rates=dividend_yield,
         discount_factors=discount_factors,
         dtype=dtype)
     return c_k_t


### PR DESCRIPTION
This pull request fixes [#50](https://github.com/google/tf-quant-finance/issues/50).

## Motivation/Rational
The argument for dividends across different option pricing models used two names when only one was needed.  This pull request updates the files using `continuous_dividends` to instead use `dividend_rates`.  This makes it easier for end-users to reuse code when using the different option pricing models.

## Explanation of Changes
As requested in issue [#50](https://github.com/google/tf-quant-finance/issues/50), deprecation decorators were used to alert users to the change in argument names.  All argument names in the `tf_quant_finance/black_scholes/` directory and sub-directories for `continuous_dividends` were changed to `dividend_rates`.

## Testing
Many of the methods changed start with the variadic argument (*), which caused test to fail as Bazel would not recognize that the deprecated argument `continuous_dividends` was in the argument list, causing an error.  When the variadic argument was removed, tests completed successfully.