### PR TITLE
Bjerksund-Stensland 1993 option pricing model

### DIFF
--- a/tf_quant_finance/black_scholes/approximations/__init__.py
+++ b/tf_quant_finance/black_scholes/approximations/__init__.py
@@ -15,10 +15,12 @@
 """Approximations to the black scholes formula."""
 
 from tf_quant_finance.black_scholes.approximations.american_option import adesi_whaley
+from tf_quant_finance.black_scholes.approximations.american_option import bjerksund_stensland
 from tensorflow.python.util.all_util import remove_undocumented  # pylint: disable=g-direct-tensorflow-import
 
 _allowed_symbols = [
     'adesi_whaley',
+    'bjerksund_stensland',
 ]
 
 remove_undocumented(__name__, _allowed_symbols)

--- a/tf_quant_finance/black_scholes/approximations/american_option.py
+++ b/tf_quant_finance/black_scholes/approximations/american_option.py
@@ -500,6 +500,9 @@ def bjerksund_stensland(*,
 
     if forwards is not None:
       forwards = tf.convert_to_tensor(forwards, dtype=dtype, name='forwards')
+      spots = tf.convert_to_tensor(
+          forwards * tf.exp(-(cost_of_carries) * expiries),
+          dtype=dtype, name='spots')
     else:
       spots = tf.convert_to_tensor(spots, dtype=dtype, name='spots')
       forwards = spots * tf.exp(cost_of_carries * expiries)
@@ -523,16 +526,16 @@ def bjerksund_stensland(*,
                 volatilities=volatilities,
                 strikes=strikes,
                 expiries=expiries,
-                forwards=forwards,
+                spots=spots,
                 discount_rates=discount_rates,
                 cost_of_carries=cost_of_carries,
                 is_call_options=is_call_options),
             # For put options, adjust inputs according to call-put transformation 
             # function:  P(S, X, T, r, b, sigma) = C(X, S, T, r - b, -b, sigma)
             tf.where(is_call_options,
-                bjerksund_stensland_model(forwards, strikes, expiries, discount_rates,
+                bjerksund_stensland_model(spots, strikes, expiries, discount_rates,
                     cost_of_carries, volatilities),
-                bjerksund_stensland_model(strikes, forwards, expiries, discount_rates -
+                bjerksund_stensland_model(strikes, spots, expiries, discount_rates -
                         cost_of_carries, -cost_of_carries, volatilities)))
 
     return american_prices

--- a/tf_quant_finance/black_scholes/approximations/american_option.py
+++ b/tf_quant_finance/black_scholes/approximations/american_option.py
@@ -343,6 +343,258 @@ def _calc_q(n, m, sign, k=1):
       (n - 1) ** 2 + tf.math.divide_no_nan(4 * m, k))) / 2
 
 
+def bjerksund_stensland(*,
+                 volatilities,
+                 strikes,
+                 expiries,
+                 spots=None,
+                 forwards=None,
+                 discount_rates=None,
+                 dividend_rates=None,
+                 cost_of_carries=None,
+                 discount_factors=None,
+                 is_call_options=None,
+                 modified_boundary=None,
+                 dtype=None,
+                 name=None):
+  """Computes the Bjerksund-Stensland option value for a batch of American options,
+    using the algorithm from the 1993 paper.
+
+  #### Example
+
+  ```python
+    import tf_quant_finance as tff
+    # Price a batch of 5 american call options.
+    volatilities = [0.2, 0.2, 0.2, 0.2, 0.2]
+    forwards = [80.0, 90.0, 100.0, 110.0, 120.0]
+    # Strikes will automatically be broadcasted to shape [5].
+    strikes = np.array([100.0])
+    # Expiries will be broadcast to shape [5], i.e. each option has strike=100
+    # and expiry = 0.25.
+    expiries = 0.25
+    cost_of_carries = -0.04
+    discount_rates = 0.08
+    computed_prices = tff.black_scholes.approximations.bjerksund_stensland_1993(
+        volatilities=volatilities,
+        strikes=strikes,
+        expiries=expiries,
+        discount_rates=discount_rates,
+        cost_of_carries=cost_of_carries,
+        forwards=forwards,
+        is_call_options=True)
+  # Expected print output of computed prices:
+  # [ 0.02912157  0.57298896  3.48587029 10.31989532 20.        ]
+  ```
+
+  #### References:
+  [1] Bjerksund, P. and Stensland G., Closed Form Valuation of American Options, 2002
+    https://core.ac.uk/download/pdf/30824897.pdf
+
+  Args:
+    volatilities: Real `Tensor` of any shape and dtype. The volatilities to
+      expiry of the options to price.
+    strikes: A real `Tensor` of the same dtype and compatible shape as
+      `volatilities`. The strikes of the options to be priced.
+    expiries: A real `Tensor` of same dtype and compatible shape as
+      `volatilities`. The expiry of each option. The units should be such that
+      `expiry * volatility**2` is dimensionless.
+    spots: A real `Tensor` of any shape that broadcasts to the shape of the
+      `volatilities`. The current spot price of the underlying. Either this
+      argument or the `forwards` (but not both) must be supplied.
+    forwards: A real `Tensor` of any shape that broadcasts to the shape of
+      `volatilities`. The forwards to maturity. Either this argument or the
+      `spots` must be supplied but both must not be supplied.
+    discount_rates: An optional real `Tensor` of same dtype as the
+      `volatilities` and of the shape that broadcasts with `volatilities`.
+      If not `None`, discount factors are calculated as e^(-rT),
+      where r are the discount rates, or risk free rates. At most one of
+      discount_rates and discount_factors can be supplied.
+      Default value: `None`, equivalent to r = 0 and discount factors = 1 when
+      discount_factors also not given.
+    dividend_rates: An optional real `Tensor` of same dtype as the
+      `volatilities` and of the shape that broadcasts with `volatilities`.
+      If not `None`, `cost_of_carries` is calculated as r - q,
+      where r are the `discount_rates` and q is `dividend_rates`. Either
+      this or `cost_of_carries` can be given.
+      Default value: `None`, equivalent to q = 0.
+    cost_of_carries: An optional real `Tensor` of same dtype as the
+      `volatilities` and of the shape that broadcasts with `volatilities`.
+      Cost of storing a physical commodity, the cost of interest paid when
+      long, or the opportunity cost, or the cost of paying dividends when short.
+      If not `None`, and `spots` is supplied, used to calculate forwards from
+      `spots`: F = e^(bT) * S, where F is the forwards price, b is the cost of
+      carries, T is expiries and S is the spot price. If `None`, value assumed
+      to be equal to the `discount_rate` - `dividend_rates`
+      Default value: `None`, equivalent to b = r.
+    discount_factors: An optional real `Tensor` of same dtype as the
+      `volatilities`. If not `None`, these are the discount factors to expiry
+      (i.e. e^(-rT)). Mutually exclusive with discount_rate and cost_of_carry.
+      If neither is given, no discounting is applied (i.e. the undiscounted
+      option price is returned). If `spots` is supplied and `discount_factors`
+      is not `None` then this is also used to compute the forwards to expiry.
+      At most one of discount_rates and discount_factors can be supplied.
+      Default value: `None`, which maps to e^(-rT) calculated from
+      discount_rates.
+    is_call_options: A boolean `Tensor` of a shape compatible with
+      `volatilities`. Indicates whether the option is a call (if True) or a put
+      (if False). If not supplied, call options are assumed.
+    modified_boundary: A boolean `Tensor` of a shape compatible with
+      `volatilities`. Indicates whether the Bjerksund-Stensland 1993 algorithm
+      (single boundary) if False or Bjerksund-Stensland 2002 algoritm (modified
+      boundary) if True, is to be used.
+    dtype: Optional `tf.DType`. If supplied, the dtype to be used for conversion
+      of any supplied non-`Tensor` arguments to `Tensor`.
+      Default value: `None` which maps to the default dtype inferred by
+        TensorFlow.
+    name: str. The name for the ops created by this function.
+      Default value: `None` which is mapped to the default name `option_price`.
+
+  Returns:
+    bjerksund_stensland_1993: A `Tensor` of the same shape as `forwards`. The
+    Bjerksund Stensland price of the options using the 1993 flat boundary model.
+
+  Raises:
+    ValueError: If both `forwards` and `spots` are supplied or if neither is
+      supplied.
+    ValueError: If both `discount_rates` and `discount_factors` is supplied.
+    ValueError: If both `dividend_rates` and `cost_of_carries` is
+      supplied.
+  """
+  if (spots is None) == (forwards is None):
+    raise ValueError('Either spots or forwards must be supplied but not both.')
+  if (discount_rates is not None) and (discount_factors is not None):
+    raise ValueError('At most one of discount_rates and discount_factors may '
+                     'be supplied')
+  if (dividend_rates is not None) and (cost_of_carries is not None):
+    raise ValueError('At most one of dividend_rates and cost_of_carries '
+                     'may be supplied')
+
+  with tf.name_scope(name or 'option_price'):
+    strikes = tf.convert_to_tensor(strikes, dtype=dtype, name='strikes')
+    dtype = strikes.dtype
+    volatilities = tf.convert_to_tensor(
+        volatilities, dtype=dtype, name='volatilities')
+    expiries = tf.convert_to_tensor(expiries, dtype=dtype, name='expiries')
+
+    if discount_rates is not None:
+      discount_rates = tf.convert_to_tensor(
+          discount_rates, dtype=dtype, name='discount_rates')
+      discount_factors = tf.exp(-discount_rates * expiries)
+    elif discount_factors is not None:
+      discount_factors = tf.convert_to_tensor(
+          discount_factors, dtype=dtype, name='discount_factors')
+      discount_rates = -tf.math.log(discount_factors) / expiries
+    else:
+      discount_rates = tf.convert_to_tensor(
+          0.0, dtype=dtype, name='discount_rates')
+      discount_factors = tf.convert_to_tensor(
+          1.0, dtype=dtype, name='discount_factors')
+
+    if dividend_rates is None:
+      dividend_rates = tf.convert_to_tensor(
+          0.0, dtype=dtype, name='dividend_rates')
+
+    if cost_of_carries is not None:
+      cost_of_carries = tf.convert_to_tensor(
+          cost_of_carries, dtype=dtype, name='cost_of_carries')
+    else:
+      cost_of_carries = discount_rates - dividend_rates
+
+    if forwards is not None:
+      forwards = tf.convert_to_tensor(forwards, dtype=dtype, name='forwards')
+    else:
+      spots = tf.convert_to_tensor(spots, dtype=dtype, name='spots')
+      forwards = spots * tf.exp(cost_of_carries * expiries)
+
+    if is_call_options is not None:
+      is_call_options = tf.convert_to_tensor(is_call_options, dtype=tf.bool,
+                                             name='is_call_options')
+    else:
+      is_call_options = tf.constant(True, name='is_call_options')
+
+    if modified_boundary is not None:
+      modified_boundary = tf.convert_to_tensor(modified_boundary, dtype=tf.bool,
+                                             name='modified_boundary')
+    else:
+      modified_boundary = tf.constant(True, name='modified_boundary')
+
+    # If cost of carry is greater than or equal to discount rate, then use 
+    # Black-Scholes option price
+    american_prices = tf.where(tf.math.logical_and(
+        tf.math.greater_equal(cost_of_carries, discount_rates), is_call_options),
+            vanilla_prices.option_price(
+                volatilities=volatilities,
+                strikes=strikes,
+                expiries=expiries,
+                forwards=forwards,
+                discount_rates=discount_rates,
+                cost_of_carries=cost_of_carries,
+                is_call_options=is_call_options),
+            # For put options, adjust inputs according to call-put transformation 
+            # function:  P(S, X, T, r, b, sigma) = C(X, S, T, r - b, -b, sigma)
+            tf.where(is_call_options,
+                _call_1993(forwards, strikes, expiries, discount_rates,
+                    cost_of_carries, volatilities),
+                _call_1993(strikes, forwards, expiries, discount_rates -
+                    cost_of_carries, -cost_of_carries, volatilities)))
+
+    return american_prices
+
+
+def _call_1993(S, K, T, r, b, sigma):
+  """Calculates the approximate value of an American call option (4) in reference [1]."""
+  
+  # The naming convention will align variables with the variables named in
+  # reference [1], but with X = _boundary_1993().
+  # [1] https://core.ac.uk/download/pdf/30824897.pdf
+
+  beta = (0.5 - b / sigma**2) + tf.math.sqrt((b / sigma**2 - 0.5)**2 + 
+          2 * r / sigma**2)
+  alpha = ((_boundary_1993(K, T, r, b, sigma, beta) - K) * 
+          (_boundary_1993(K, T, r, b, sigma, beta))**(-beta))
+
+  return tf.where(S >= _boundary_1993(K, T, r, b, sigma, beta),
+          S - K,
+          alpha * S**beta -
+          alpha * _phi_1993(S, T, beta, _boundary_1993(K, T, r, b, sigma, beta), 
+              _boundary_1993(K, T, r, b, sigma, beta), r, b, sigma) +
+          _phi_1993(S, T, 1, _boundary_1993(K, T, r, b, sigma, beta), 
+              _boundary_1993(K, T, r, b, sigma, beta), r, b, sigma) -
+          _phi_1993(S, T, 1, K, _boundary_1993(K, T, r, b, sigma, beta), r, b, sigma) - 
+          K * _phi_1993(S, T, 0, _boundary_1993(K, T, r, b, sigma, beta), 
+              _boundary_1993(K, T, r, b, sigma, beta), r, b, sigma) +
+          K * _phi_1993(S, T, 0, K, _boundary_1993(K, T, r, b, sigma, beta), r, b, sigma))
+
+
+def _phi_1993(S, T, gamma, H, X, r, b, sigma):
+  """Computes the value of the Phi (7) function in reference [1]."""
+  
+  # The naming convention will align variables with the variables named in
+  # reference [1], but with X = _boundary_1993().
+  # [1] https://core.ac.uk/download/pdf/30824897.pdf
+
+  kappa = (2 * b) / sigma**2 + (2 * gamma - 1)
+  d1 = -(tf.math.log(S/H) + (b + (gamma - 0.5) * sigma**2) * T) / (sigma * tf.math.sqrt(T))
+  d2 = -(tf.math.log(X**2 / (S * H)) + (b + (gamma - 0.5) * sigma**2) * T) / (sigma * tf.math.sqrt(T))
+  lambd = -r + gamma * b + 0.5 * gamma * (gamma - 1) * sigma**2
+
+  return tf.math.exp(lambd * T) * S**gamma * (_ncdf(d1) - (X/S)**kappa * _ncdf(d2))
+
+
+def _boundary_1993(K, T, r, b, sigma, beta):
+  """Computes the early exercise boundary (10) in reference [1]."""
+
+  # The naming convention will align variables with the variables named in
+  # reference [1].
+  # [1] https://core.ac.uk/download/pdf/30824897.pdf
+
+  b0 = tf.math.maximum(K, (r / (r - b)) * K)
+  binfinity = beta / (beta - 1) * K
+  hT = -(b * T + 2 * sigma * tf.math.sqrt(T)) * (K**2 / ((binfinity - b0) * b0))
+
+  return b0 + (binfinity - b0) * (1 - tf.math.exp(hT))
+
+
 def _ncdf(x):
   return (tf.math.erf(x / _SQRT_2) + 1) / 2
 

--- a/tf_quant_finance/black_scholes/approximations/american_option_test.py
+++ b/tf_quant_finance/black_scholes/approximations/american_option_test.py
@@ -220,7 +220,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
                                      expiries, expected_prices):
     """Tests Bjerksund Stensland 1993 prices for negative cost_of_carries."""
     cost_of_carries = np.array([-0.04] * 10)
-    forwards = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
+    spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
     strikes = np.array([100.0] * 10)
     is_call_options = np.array([True] * 5 + [False] * 5)
     computed_prices = bjerksund_stensland(
@@ -229,7 +229,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
         expiries=expiries,
         discount_rates=discount_rates,
         cost_of_carries=cost_of_carries,
-        forwards=forwards,
+        spots=spots,
         is_call_options=is_call_options,
         modified_boundary=False,
         dtype=tf.float64)
@@ -253,7 +253,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
                                      expiries, expected_prices):
     """Tests Bjerksund Stensland 1993 prices for positive cost_of_carries."""
     cost_of_carries = np.array([0.04] * 10)
-    forwards = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
+    spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
     strikes = np.array([100.0] * 10)
     is_call_options = [True] * 5 + [False] * 5
     computed_prices = bjerksund_stensland(
@@ -262,7 +262,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
         expiries=expiries,
         discount_rates=discount_rates,
         cost_of_carries=cost_of_carries,
-        forwards=forwards,
+        spots=spots,
         is_call_options=is_call_options,
         modified_boundary=False,
         dtype=tf.float64)
@@ -284,7 +284,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
   def test_bs1993_prices_carries_equal_rate(self, discount_rates, cost_of_carries,
                                       volatilities, expiries, expected_prices):
     """Tests Bjerksund Stensland 1993 prices for zero cost_of_carries."""
-    forwards = np.array([80.0, 90.0, 100.0, 110.0, 120.0])
+    spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0])
     strikes = np.array([100.0] * 5)
     is_call_options = np.array([False] * 5)
     computed_prices = bjerksund_stensland(
@@ -293,7 +293,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
         expiries=expiries,
         discount_rates=discount_rates,
         cost_of_carries=cost_of_carries,
-        forwards=forwards,
+        spots=spots,
         is_call_options=is_call_options,
         modified_boundary=False,
         dtype=tf.float64)
@@ -307,13 +307,13 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
        [2.30, 4.71, 8.44, 13.74, 20.85, 25.61, 20.04, 15.47, 11.78, 8.87]),
       (0.08, 0.0, 0.2, 3.0,
        [3.95, 7.20, 11.64, 17.24, 23.93, 22.12, 16.14, 11.64, 8.31, 5.89]),
-      #(0.08, 0.04, 0.4, 3.0,
-      # [6.88, 11.49, 17.21, 23.84, 31.16, 20.32, 13.43, 8.86, 5.83, 3.83]),      # Results are suspect, see PR #54
+      (0.08, 0.04, 0.2, 3.0,
+       [6.88, 11.49, 17.21, 23.84, 31.16, 20.32, 13.43, 8.86, 5.83, 3.83]),
   )
   def test_bs1993_prices_long_term1(self, discount_rates, cost_of_carries,
                                       volatilities, expiries, expected_prices):
     """Tests Bjerksund Stensland 1993 prices for long-term options."""
-    forwards = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
+    spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0] * 2)
     strikes = np.array([100.0] * 10)
     is_call_options = [True] * 5 + [False] * 5
     computed_prices = bjerksund_stensland(
@@ -322,7 +322,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
         expiries=expiries,
         discount_rates=discount_rates,
         cost_of_carries=cost_of_carries,
-        forwards=forwards,
+        spots=spots,
         is_call_options=is_call_options,
         modified_boundary=False,
         dtype=tf.float64)
@@ -338,7 +338,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
   def test_bs1993_prices_long_term2(self, discount_rates, cost_of_carries,
                                       volatilities, expiries, expected_prices):
     """Tests Bjerksund Stensland 1993 prices for long-term options."""
-    forwards = np.array([80.0, 90.0, 100.0, 110.0, 120.0])
+    spots = np.array([80.0, 90.0, 100.0, 110.0, 120.0])
     strikes = np.array([100.0] * 5)
     is_call_options = np.array([False] * 5)
     computed_prices = bjerksund_stensland(
@@ -347,7 +347,7 @@ class AmericanPrice(parameterized.TestCase, tf.test.TestCase):
         expiries=expiries,
         discount_rates=discount_rates,
         cost_of_carries=cost_of_carries,
-        forwards=forwards,
+        spots=spots,
         is_call_options=is_call_options,
         modified_boundary=False,
         dtype=tf.float64)


### PR DESCRIPTION
## Motiviation/Rational

While the intent is to add both of the Bjerksund-Stensland option pricing models for american exercise options, this pull request is for the 1993 model, with the 2002 model to follow shortly after.

## Testing

The primary source used is the description of the 1993 model in the paper on the 2002 model [here](https://core.ac.uk/download/pdf/30824897.pdf).  Included in the paper are four tables with values for the 1993 model (referenced as "flat boundary approximation").  A test was run checking all of the values (source code can be provided upon request):

```
Closed Form Valuation of American Options, 2002
Table 1, pg. 9 - 1993 model
Section 1, Calls:  [ 0.03  0.57  3.49 10.32 20.  ]  Puts:  [20.41 11.25  4.4   1.12  0.18]
Section 2, Calls:  [ 0.03  0.57  3.46 10.29 20.  ]  Puts:  [20.22 11.14  4.35  1.11  0.18]
Section 3, Calls:  [ 1.05  3.25  7.37 13.47 21.23]  Puts:  [21.44 13.91  8.27  4.52  2.29]
Section 4, Calls:  [ 0.21  1.34  4.65 10.94 20.  ]  Puts:  [20.95 12.63  6.37  2.65  0.92]
Table 2, pg. 10 - 1993 model
Section 1, Calls:  [ 0.05  0.85  4.44 11.66 20.9 ]  Puts:  [20.   10.19  3.51  0.78  0.11]
Section 2, Calls:  [ 0.05  0.84  4.4  11.55 20.69]  Puts:  [20.   10.17  3.49  0.77  0.11]
Section 3, Calls:  [ 1.29  3.82  8.35 14.8  22.71]  Puts:  [20.53 12.91  7.42  3.93  1.93]
Section 4, Calls:  [ 0.41  2.18  6.5  13.42 22.06]  Puts:  [20.   10.7   4.7   1.71  0.52]
Table 3, pg. 11 - 1993 model
Section 1, Puts:  [20.   10.01  3.16  0.65  0.09]
Section 2, Puts:  [20.   10.    2.86  0.54  0.07]
Section 3, Puts:  [20.28 12.48  7.04  3.66  1.77]
Section 4, Puts:  [20.   10.24  4.11  1.37  0.39]
Table 4, pg. 12 - 1993 model
Section 1, Calls:  [ 2.3   4.71  8.44 13.74 20.85]  Puts:  [25.61 20.04 15.47 11.78  8.87]
Section 2, Calls:  [ 3.95  7.2  11.64 17.24 23.93]  Puts:  [22.12 16.14 11.64  8.31  5.89]
Section 3, Calls:  [16.75 22.25 28.31 34.84 41.77]  Puts:  [28.42 23.97 20.34 17.34 14.86]
Section 4, Puts:  [20.   11.67  6.9   4.12  2.48]
```

All of the values match, with the only exception being those in Table 4, Section 3.  Confirming the values using online calculators, such as this one [here](http://janroman.dhis.org/calc/BjerksundStensland.php), led to the conclusion that the values in Table 4, Section 3 are not correct - but I would appreciate the input of others.

This PR is in draft status as I still need to add tests to american_option_test.py.