### PR TITLE
Discrete geometric pricer under Heston vol

### DIFF
--- a/tf_quant_finance/models/heston/approximations/BUILD
+++ b/tf_quant_finance/models/heston/approximations/BUILD
@@ -10,6 +10,7 @@ py_library(
     deps = [
         ":calibration",
         ":european_option",
+        ":asian_prices",
     ],
 )
 
@@ -61,6 +62,31 @@ py_test(
         "//tf_quant_finance",
         # test util,
         # absl/testing:parameterized dep,
+        # numpy dep,
+        # tensorflow dep,
+    ],
+)
+
+py_library(
+    name = "asian_prices",
+    srcs = ["asian_prices.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//tf_quant_finance/types",
+        "//tf_quant_finance/utils",
+        # numpy dep,
+        # tensorflow dep,
+    ],
+)
+
+py_test(
+    name = "asian_prices_test",
+    srcs = ["asian_prices_test.py"],
+    python_version = "PY3",
+    deps = [
+        ":asian_prices",
+        "//tf_quant_finance",
+        # test util,
         # numpy dep,
         # tensorflow dep,
     ],

--- a/tf_quant_finance/models/heston/approximations/__init__.py
+++ b/tf_quant_finance/models/heston/approximations/__init__.py
@@ -15,11 +15,13 @@
 
 from tf_quant_finance.models.heston.approximations.calibration import calibration
 from tf_quant_finance.models.heston.approximations.european_option import european_option_price
+from tf_quant_finance.models.heston.approximations.asian_prices import asian_option_price
 from tensorflow.python.util.all_util import remove_undocumented  # pylint: disable=g-direct-tensorflow-import
 
 _allowed_symbols = [
     'calibration',
     'european_option_price',
+    'asian_option_price'
 ]
 
 remove_undocumented(__name__, _allowed_symbols)

--- a/tf_quant_finance/models/heston/approximations/asian_prices.py
+++ b/tf_quant_finance/models/heston/approximations/asian_prices.py
@@ -1,0 +1,528 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Heston prices of a batch of Asian options."""
+
+import numpy as np
+import tensorflow.compat.v2 as tf
+from tf_quant_finance import types
+from tf_quant_finance import utils
+from tf_quant_finance.math import integration
+from tf_quant_finance.black_scholes import AveragingType
+from tf_quant_finance.black_scholes import AveragingFrequency
+__all__ = [
+    'asian_option_price'
+]
+
+
+def asian_option_price(
+    *,
+    variances: types.RealTensor,
+    mean_reversion: types.RealTensor,
+    theta: types.RealTensor,
+    volvol: types.RealTensor,
+    rho: types.RealTensor,
+    strikes: types.RealTensor,
+    expiries: types.RealTensor,
+    spots: types.RealTensor = None,
+    forwards: types.RealTensor = None,
+    sampling_times: types.RealTensor = None,
+    past_fixings: types.RealTensor = None,
+    discount_rates: types.RealTensor = None,
+    dividend_rates: types.RealTensor = None,
+    discount_factors: types.RealTensor = None,
+    is_call_options: types.BoolTensor = None,
+    averaging_type: AveragingType = AveragingType.GEOMETRIC,
+    averaging_frequency: AveragingFrequency = AveragingFrequency.DISCRETE,
+    integration_method: integration.IntegrationMethod = None,
+    dtype: tf.DType = None,
+    name: str = None,
+    **kwargs) -> types.RealTensor:
+  """Computes the Heston price for a batch of asian options.
+
+  Discrete and continuous geometric asian options can be priced using a
+  semi-analytical expression in the Heston model.
+
+  #### Example
+  ```python
+    # Price a batch of seasoned discrete geometric asians in Heston model
+    # This example reproduces some prices from the reference paper
+    variances = 0.09
+    mean_reversion = 1.15
+    volvol = 0.39
+    theta = 0.0348
+    rho = -0.64
+    spots = 100.0
+    strikes = [90.0, 100.0, 110.0]
+    discount_rates = 0.05
+
+    T = 0.5
+    expiries = T
+    sampling_times = np.linspace(1/365, T, 182)[:, np.newaxis]
+
+    computed_prices_asians = asian_option_price(
+      variances=variances,
+      mean_reversion=mean_reversion,
+      theta=theta,
+      volvol=volvol,
+      rho=rho,
+      strikes=strikes,
+      expiries=expiries,
+      spots=spots,
+      sampling_times=sampling_times,
+      discount_rates=discount_rates
+    )
+    # Expected print output of computed prices:
+    # [[11.884178 ], [ 5.080889 ], [ 1.3527349]]
+  ```
+
+  #### References:
+  [1] B. Kim, J. Kim, J. Kim & I. S. Wee, "A Recursive Method for Discretely
+    Monitored Geometric Asian Option Prices", Bull. Korean Math. Soc. 53,
+    733-749 (2016)
+
+  Args:
+    variances: Real `Tensor` of any shape compatible with a `batch_shape` and
+      and any real dtype. The initial value of the variance.
+    mean_reversion: A real `Tensor` of the same dtype and compatible shape as
+      `strikes`. Corresponds to the mean reversion rate.
+    theta: A real `Tensor` of the same dtype and compatible shape as
+      `strikes`. Corresponds to the long run price variance.
+    volvol: A real `Tensor` of the same dtype and compatible shape as
+      `strikes`. Corresponds to the volatility of the volatility.
+    rho: A real `Tensor` of the same dtype and compatible shape as
+      `strikes`. Corresponds to the correlation between dW_{X}` and `dW_{V}`.
+    strikes: A real `Tensor` of the same dtype and compatible shape as
+      `volatilities`. The strikes of the options to be priced.
+    expiries: A real `Tensor` of same dtype and compatible shape as
+      `volatilities`. The expiry of each option. The units should be such that
+      `expiry * volatility**2` is dimensionless.
+    spots: A real `Tensor` of any shape that broadcasts to the shape of the
+      `volatilities`. The current spot price of the underlying. Either this
+      argument or the `forwards` (but not both) must be supplied.
+    forwards: A real `Tensor` of any shape that broadcasts to the shape of
+      `volatilities`. The forwards to maturity. Either this argument or the
+      `spots` must be supplied but both must not be supplied.
+    sampling_times: A real `Tensor` of same dtype as expiries and shape
+      `[n] + volatilities_shape` where n is the number of sampling times for
+      the asian options
+      Default value: `None`, which will raise an error for discrete sampling
+      asian options
+    past_fixings: A real `Tensor` of same dtype as spots or forwards and shape
+      `[n] + volatilities_shape` where n is the number of past fixings that
+      have already been observed
+      Default value: `None`, equivalent to no past fixings (ie. unseasoned)
+    discount_rates: An optional real `Tensor` of same dtype as the
+      `volatilities` and of the shape that broadcasts with `volatilities`.
+      If not `None`, discount factors are calculated as e^(-rT),
+      where r are the discount rates, or risk free rates. At most one of
+      `discount_rates` and `discount_factors` can be supplied.
+      Default value: `None`, equivalent to r = 0 and discount factors = 1 when
+      `discount_factors` also not given.
+    dividend_rates: An optional real `Tensor` of same dtype as the
+      `volatilities` and of the shape that broadcasts with `volatilities`.
+      Default value: `None`, equivalent to q = 0.
+    discount_factors: An optional real `Tensor` of same dtype as the
+      `volatilities`. If not `None`, these are the discount factors to expiry
+      (i.e. e^(-rT)). Mutually exclusive with `discount_rates`. If neither is
+      given, no discounting is applied (i.e. the undiscounted option price is
+      returned). If `spots` is supplied and `discount_factors` is not `None`
+      then this is also used to compute the forwards to expiry. At most one of
+      `discount_rates` and `discount_factors` can be supplied.
+      Default value: `None`, which maps to e^(-rT) calculated from
+      discount_rates.
+    is_call_options: A boolean `Tensor` of a shape compatible with
+      `volatilities`. Indicates whether the option is a call (if True) or a put
+      (if False). If not supplied, call options are assumed.
+    averaging_type: Enum value of AveragingType to select the averaging method
+      for the payoff calculation
+      Default value: AveragingType.GEOMETRIC
+    averaging_frequency: Enum value of AveragingFrequency to select the
+      averaging type for the payoff calculation (discrete vs continuous)
+      Default value: AveragingFrequency.DISCRETE
+    integration_method: An instance of `math.integration.IntegrationMethod`.
+      Default value: `None` which maps to Gaussian quadrature.
+    dtype: Optional `tf.DType`. If supplied, the dtype to be used for conversion
+      of any supplied non-`Tensor` arguments to `Tensor`.
+      Default value: None which maps to the default dtype inferred by
+      TensorFlow.
+    name: str. The name for the ops created by this function.
+      Default value: `None` which is mapped to the default name 
+      `discrete_geometric_average_price`.
+    **kwargs: Additional parameters for the underlying integration method.
+      If not supplied, uses bounds `lower=1e-9`, `upper=100`.
+
+  Returns:
+    option_prices: A `Tensor` of the same shape as `strikes`. The Heston price
+    of the options.
+
+  Raises:
+    ValueError: If both `forwards` and `spots` are supplied or if neither is
+      supplied.
+    ValueError: If both `discount_rates` and `discount_factors` is supplied.
+    ValueError: If option is arithmetic.
+    NotImplementedError: if option is continuous averaging.
+    NotImplementedError: if any of the Heston model parameters are of type
+      PiecewiseConstantFunc.
+  """
+  if (spots is None) == (forwards is None):
+    raise ValueError('Either spots or forwards must be supplied but not both.')
+  if (discount_rates is not None) and (discount_factors is not None):
+    raise ValueError('At most one of discount_rates and discount_factors may '
+                     'be supplied')
+  if averaging_type == AveragingType.ARITHMETIC:
+    raise ValueError('Cannot price arithmetic averaging asians analytically '
+                     'under Heston model')
+  if averaging_frequency == AveragingFrequency.DISCRETE:
+    if sampling_times is None:
+      raise ValueError('Sampling times required for discrete sampling asians')
+  if averaging_frequency == AveragingFrequency.CONTINUOUS:
+    raise NotImplementedError('Pricing continuous averaging asians not yet '
+                              'supported')
+
+  with tf.name_scope(name or 'asian_option_price'):
+    strikes = tf.convert_to_tensor(strikes, dtype=dtype, name='strikes')
+    dtype = strikes.dtype
+    results_shape = strikes.shape
+
+    expiries = tf.convert_to_tensor(expiries, dtype=dtype, name='expiries')
+    expiries = tf.broadcast_to(expiries, strikes.shape)
+    sampling_times = tf.convert_to_tensor(
+        sampling_times, dtype=dtype, name='sampling_times')
+    sampling_times = tf.broadcast_to(
+        sampling_times, [sampling_times.shape[0], strikes.shape[0]])
+
+    # Fail assertion if sampling comes after expiry
+    if averaging_frequency == AveragingFrequency.DISCRETE:
+      tf.debugging.assert_equal(
+        tf.math.maximum(sampling_times[-1], expiries), expiries,
+        'Sampling times cannot occur after expiry times'
+      )
+
+    variances = tf.convert_to_tensor(variances, dtype=dtype, name='variances')
+    variances = tf.broadcast_to(variances, strikes.shape)
+    mean_reversion = tf.convert_to_tensor(
+        mean_reversion, dtype=dtype, name='mean_reversion')
+    mean_reversion = tf.broadcast_to(mean_reversion, strikes.shape)
+    theta = tf.convert_to_tensor(theta, dtype=dtype, name='theta')
+    theta = tf.broadcast_to(theta, strikes.shape)
+    volvol = tf.convert_to_tensor(volvol, dtype=dtype, name='volvol')
+    volvol = tf.broadcast_to(volvol, strikes.shape)
+    rho = tf.convert_to_tensor(rho, dtype=dtype, name='rho')
+    rho = tf.broadcast_to(rho, strikes.shape)
+
+    if discount_rates is not None:
+      discount_rates = tf.convert_to_tensor(
+          discount_rates, dtype=dtype, name='discount_rates')
+      discount_factors = tf.exp(-discount_rates * expiries)
+    elif discount_factors is not None:
+      discount_factors = tf.convert_to_tensor(
+          discount_factors, dtype=dtype, name='discount_factors')
+      discount_rates = -tf.math.log(discount_factors) / expiries
+    else:
+      discount_rates = tf.convert_to_tensor(
+          0.0, dtype=dtype, name='discount_rates')
+      discount_factors = tf.convert_to_tensor(
+          1.0, dtype=dtype, name='discount_factors')
+
+    if dividend_rates is None:
+      dividend_rates = tf.convert_to_tensor(
+          0.0, dtype=dtype, name='dividend_rates')
+
+    if forwards is not None:
+      forwards = tf.convert_to_tensor(forwards, dtype=dtype, name='forwards')
+      spots = forwards * tf.exp(-(discount_rates - dividend_rates) * expiries)
+    else:
+      spots = tf.convert_to_tensor(spots, dtype=dtype, name='spots')
+      forwards = spots * tf.exp((discount_rates - dividend_rates) * expiries)
+
+    forwards = tf.broadcast_to(forwards, strikes.shape)
+    spots = tf.broadcast_to(spots, strikes.shape)
+
+    #  To account for seasoning, we keep pricing time fixed at t=0 and adjust
+    #  the pricing parameters as follows:
+    #    - calculate prefactor running_prod ^ (1/#_total_fixings)
+    #    - strikes \to strikes / prefactor
+    #    - k_star \to #_past_fixings
+    #    - prepend #_past_fixings negative values to sampling times
+    #    - prices \to prefactor * prices
+    #
+    #  This is slightly different to the approach in the paper, where instead
+    #  t is allowed to increase above 0 as pricing time moves forwards
+
+    if past_fixings is None:
+      running_accumulator = tf.constant(1.0, dtype=dtype)
+      fixing_count = 0
+    else:
+      past_fixings = tf.convert_to_tensor(
+        past_fixings, dtype=dtype, name='past_fixings')
+      running_accumulator = tf.reduce_prod(past_fixings, 0)
+      fixing_count = utils.get_shape(past_fixings)[0]
+
+    start_times = tf.zeros(spots.shape[0], dtype=dtype)
+    tau_k = tf.concat([tf.expand_dims(start_times, axis=0),
+                      sampling_times,
+                      tf.expand_dims(expiries, axis=0)], 0)
+
+    n = utils.get_shape(sampling_times)[0] + fixing_count
+    prefactor = running_accumulator ** (1 / n)
+    adj_strikes = strikes / prefactor
+
+    # Shape [batch_shape, (num_times + fixing_count)] - in this operation we
+    # are adding additional negative fixings that account for the already
+    # observed fixings of this asian option
+    sampling_times = tf.concat(
+      [
+        -1 * tf.ones([fixing_count, utils.get_shape(sampling_times)[1]],
+                     dtype=dtype),
+        sampling_times
+      ],
+      0
+    )
+
+    k_star = fixing_count
+
+    # Prepare inputs to build an integrand_function
+    spots = tf.expand_dims(spots, -1)
+    rho = tf.expand_dims(rho, -1)
+    variances = tf.expand_dims(variances, -1)
+    mean_reversion = tf.expand_dims(mean_reversion, -1)
+    volvol = tf.expand_dims(volvol, -1)
+    theta = tf.expand_dims(theta, -1)
+    expiries = tf.expand_dims(expiries, -1)
+    strikes = tf.expand_dims(adj_strikes, -1)
+    start_times = tf.expand_dims(start_times, -1)
+    discount_rates = tf.expand_dims(discount_rates, -1)
+    dividend_rates = tf.expand_dims(dividend_rates, -1)
+    prefactor = tf.expand_dims(prefactor, -1)
+
+    d_tau_k = tau_k[1:] - tau_k[:-1]
+
+    k_tensor = tf.range(k_star+1, n+2, dtype=dtype)
+    k_tensor = tf.ones(
+      shape=k_tensor.shape + sampling_times.shape[1],
+      dtype=dtype
+    ) * tf.expand_dims(k_tensor, 1)
+
+    asian_prices_handler = _AsianPricesHandler(
+      spots=tf.cast(spots, np.complex128),
+      discount_rates=tf.cast(discount_rates, np.complex128),
+      dividend_rates=tf.cast(dividend_rates, np.complex128),
+      variances=tf.cast(variances, np.complex128),
+      mean_reversion=tf.cast(mean_reversion, np.complex128),
+      volvol=tf.cast(volvol, np.complex128),
+      rho=tf.cast(rho, np.complex128),
+      theta=tf.cast(theta, np.complex128),
+      strikes=tf.cast(strikes, np.complex128),
+      start_times=tf.cast(start_times, np.complex128),
+      expiries=tf.cast(expiries, np.complex128),
+      sampling_times=tf.cast(sampling_times, np.complex128),
+      k_tensor=tf.cast(k_tensor, np.complex128),
+      d_tau_k=tf.cast(d_tau_k, np.complex128),
+      k_star=k_star,
+      n=n,
+      dtype=np.complex128
+    )
+
+    if integration_method is None:
+      integration_method = integration.IntegrationMethod.GAUSS_LEGENDRE
+
+    f = lambda x: tf.cast(asian_prices_handler.integrand(x), dtype)
+
+    if 'lower' not in kwargs:
+      kwargs['lower'] = 1e-9
+    if 'upper' not in kwargs:
+      kwargs['upper'] = 100
+
+    kwargs['lower'] = tf.constant(kwargs['lower'], dtype=dtype)
+    kwargs['upper'] = tf.constant(kwargs['upper'], dtype=dtype)
+
+    integral = integration.integrate(
+      f,
+      method=integration_method,
+      dtype=dtype,
+      **kwargs
+    )
+
+    asian_forward = tf.cast(
+      tf.math.real(asian_prices_handler.phi(1, 0)),
+      dtype=dtype
+    )
+    dcfs = tf.math.exp(-discount_rates * expiries)
+
+    # calls currently [`batch_size`, 1], then reshaped to match results_shape
+    calls = prefactor * dcfs * ((asian_forward - strikes) / 2
+                                + tf.expand_dims(integral, -1) / np.pi)
+    calls = tf.reshape(calls, results_shape)
+
+    if is_call_options is None:
+      return calls
+
+    is_call_options = tf.convert_to_tensor(
+      is_call_options, dtype=bool, name='is_call_options')
+    is_call_options = tf.reshape(is_call_options, results_shape)
+
+    # puts currently [`batch_size`, 1], then reshaped to match results_shape
+    puts = prefactor * dcfs * ((strikes - asian_forward) / 2
+                               + tf.expand_dims(integral, -1) / np.pi)
+    puts = tf.reshape(puts, results_shape)
+
+    return tf.where(is_call_options, calls, puts)
+
+
+@utils.dataclass
+class _AsianPricesHandler:
+  """Handles the various pricing functions for asian options."""
+  spots: types.RealTensor
+  discount_rates: types.RealTensor
+  dividend_rates: types.RealTensor
+  variances: types.RealTensor
+  mean_reversion: types.RealTensor
+  theta: types.RealTensor
+  volvol: types.RealTensor
+  rho: types.RealTensor
+  start_times: types.RealTensor
+  expiries: types.RealTensor
+  strikes: types.RealTensor
+  sampling_times: types.RealTensor
+  k_tensor: types.RealTensor
+  d_tau_k: types.RealTensor
+  k_star: int
+  n: int
+  dtype: tf.DType
+
+  def f(self, z1, z2, tau):
+    """Calculates F(z1, z2) (eq. (11) from the referenced paper)"""
+    x = tf.math.sqrt(tf.math.pow(self.mean_reversion, 2)
+                     - 2 * z1 * tf.math.pow(self.volvol, 2))
+
+    term_1 = tf.math.cosh(0.5 * tau * x)
+    term_2 = ((self.mean_reversion - z2 * tf.math.pow(self.volvol, 2))
+               * tf.math.sinh(0.5 * tau * x)) / x
+
+    return term_1 + term_2
+
+  def f_tilde(self, z1, z2, tau):
+    """Calculates F_tilde(z1, z2) (eq. (11) from the referenced paper)"""
+    x = tf.math.sqrt(tf.math.pow(self.mean_reversion, 2)
+                     - 2 * z1 * tf.math.pow(self.volvol, 2))
+
+    term_1 = 0.5 * x * tf.math.sinh(0.5 * tau * x)
+    term_2 = 0.5 * ((self.mean_reversion - z2 * tf.math.pow(self.volvol, 2))
+                     * tf.math.cosh(0.5 * tau * x))
+
+    return term_1 + term_2
+
+  def a(self, s, w):
+    """Calculates a(s, w) (eq. (17) from the referenced paper)"""
+    raw_drift = self.discount_rates - self.dividend_rates
+    corr_drift = self.rho * self.mean_reversion * self.theta / self.volvol
+    mod_drift = raw_drift - corr_drift
+
+    # summed_samplings shape [`batch_size`, 1] after the reduction
+    summed_samplings = tf.reduce_sum(self.sampling_times[self.k_star:],
+                                     axis=0)[..., tf.newaxis]
+
+    n_c = tf.constant(self.n, dtype=self.dtype) 
+    k_star_c = tf.constant(self.k_star, dtype=self.dtype)
+
+    term_1 = ((s * (n_c - k_star_c) / n_c + w)
+               * (tf.math.log(self.spots)
+                  - self.rho * self.variances / self.volvol
+                  - self.start_times * mod_drift))
+    term_2 = (s * (summed_samplings) / n_c + w * self.expiries) * mod_drift
+
+    return term_1 + term_2
+
+  def z(self, s, w):
+    """Calculates z_k(s, w) (eq. (14) from the referenced paper)"""
+    k_s_w_tensor = tf.expand_dims(self.n - self.k_tensor + 1, 2) * s + self.n * w
+    term_1 = ((2 * self.rho * self.mean_reversion - self.volvol)
+               * (k_s_w_tensor) / (self.volvol * self.n))
+    term_2 = ((1 - tf.math.pow(self.rho, 2))
+               * tf.cast(tf.math.pow(k_s_w_tensor, 2), dtype=self.dtype)
+               / tf.cast(tf.math.pow(self.n, 2), dtype=self.dtype))
+
+    return 0.5 * (term_1 + term_2)
+
+  def omega_k(self, s, w):
+    """Calculates \omega_k(s, w) (eq. (15) from the referenced paper)"""
+    return tf.concat([tf.expand_dims(self.start_times, 1) * s,
+                      tf.expand_dims(tf.ones((self.sampling_times.shape[1], self.n - self.k_star), dtype=self.dtype) * self.rho / (self.volvol * self.n), 2) * s,
+                      tf.expand_dims(self.rho / self.volvol, 1) * w], 1)
+
+  def omega_tilde_k(self, s, w, z_k_tensor):
+    """Calculates \tilde{\omega}_k(s, w) (eq. (19) from the referenced paper)"""
+    omega_tilde = self.omega_k(s, w)
+    mr_v2 = self.mean_reversion / tf.math.pow(self.volvol, 2)
+
+    x0 = omega_tilde.shape[1] - 1
+    ta = tf.TensorArray(omega_tilde.dtype, size=0, dynamic_size=True, clear_after_read=False)
+    last_row = omega_tilde[:,0,:]
+
+    condition = lambda q, ta, last_row: tf.greater_equal(q, 0)
+
+    def modify_row(q, row, last_row):
+            d_tau = tf.expand_dims(self.d_tau_k[q], 1)
+            z_k = z_k_tensor[q]
+
+            return row + mr_v2 - (2 * self.f_tilde(z_k, last_row, d_tau)
+                                  / (self.f(z_k, last_row, d_tau)
+                                  * tf.math.pow(self.volvol, 2)))
+
+    def body(q, ta, last_row):
+        row = tf.cond(
+            tf.less(q, x0),
+            true_fn = lambda: modify_row(q, omega_tilde[:,q,:], last_row),
+            false_fn = lambda: omega_tilde[:,q,:]
+        )
+
+        ta = ta.write(q, row)
+        last_row = row
+
+        return (q-1, ta, last_row)
+
+    _, r, _ = tf.while_loop(condition, body, [x0, ta, last_row])
+
+    return r.stack()
+
+  def phi(self, s, w):
+    """Calculates Phi(s, w) (eq. (21) from the referenced paper)"""
+    z_k_tensor = self.z(s, w)
+    omega_tilde = self.omega_tilde_k(s, w, z_k_tensor)
+    tte = (self.expiries - self.start_times)
+
+    term_1 = self.a(s, w) + omega_tilde[0,:] * self.variances
+    term_2 = (tf.math.pow(self.mean_reversion, 2) * self.theta
+              * tte / tf.math.pow(self.volvol, 2))
+    term_3 = 2 * self.mean_reversion * self.theta / tf.math.pow(self.volvol, 2)
+
+    # summation shape [`batch_size`, `s`] after the reduction, where `s` is the
+    # tensor of integration variable values
+    summation = tf.reduce_sum(tf.math.log(self.f(
+      z_k_tensor,
+      omega_tilde[1:,:],
+      tf.expand_dims(self.d_tau_k, 2)
+    )), 0)
+
+    return tf.math.exp(term_1 + term_2 - term_3 * summation)
+
+  def integrand(self, x):
+    """Calculates pricing integrand (eq. (23), (24) from the referenced paper)"""
+    x = tf.cast(x, self.dtype)
+    w = tf.zeros_like(x)
+
+    term_1 = self.phi(1 + x*1j, w) - self.strikes * self.phi(x*1j, w)
+    term_2 = tf.math.exp(-1j * x * tf.math.log(self.strikes))/(x * 1j)
+
+    return tf.math.real(term_1 * term_2)

--- a/tf_quant_finance/models/heston/approximations/asian_prices_test.py
+++ b/tf_quant_finance/models/heston/approximations/asian_prices_test.py
@@ -1,0 +1,292 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for asian_prices."""
+
+from absl.testing import parameterized
+
+import numpy as np
+import tensorflow.compat.v2 as tf
+
+import tf_quant_finance as tff
+from tf_quant_finance.models.heston.approximations import asian_option_price
+from tf_quant_finance.models.heston.approximations import european_option_price
+from tf_quant_finance.models.heston import HestonModel
+from tensorflow.python.framework import test_util  # pylint: disable=g-direct-tensorflow-import
+
+
+@test_util.run_all_in_graph_and_eager_modes
+class AsianPriceTest(parameterized.TestCase, tf.test.TestCase):
+  """Tests for methods for the Heston asian pricing module"""
+
+  def test_option_prices(self):
+    """Tests for methods for the asian pricing module. Expected results come
+    from tables (1)-(3) in 'A Recursive Method for Discretely Monitored
+    Geometric Asian Option Prices', Bull. Korean Math. Soc. 53, 733-749 (2016)
+    by B. Kim, J. Kim, J. Kim & I. S. Wee (1y expiry, weekly sampling)
+    """
+    variances = tf.constant([0.09, 0.09, 0.09])
+    mean_reversion = tf.constant([1.15, 1.15, 1.15])
+    volvol = tf.constant([0.39, 0.39, 0.39])
+    theta = tf.constant([0.0348, 0.0348, 0.0348])
+    rho = tf.constant([-0.64, -0.64, -0.64])
+    spots = tf.constant([100.0, 100.0, 100.0])
+    strikes = tf.constant([90.0, 100.0, 110.0])
+
+    discount_rates = tf.constant([0.05, 0.05, 0.05])
+    dividend_rates = tf.constant([0.0, 0.0, 0.0])
+
+    T = 1.0
+
+    t_n = tf.constant(np.linspace(0, T, 52)[1:], dtype=np.float32)
+    expiries = tf.constant([T, T, T])
+    sampling_times = tf.ones(shape=t_n.shape + spots.shape) * tf.expand_dims(t_n, 1)
+
+    expected_prices = tf.constant([13.6950, 7.2243, 2.9479], dtype=np.float32)
+
+    computed_prices = asian_option_price(
+      variances=variances,
+      mean_reversion=mean_reversion,
+      theta=theta,
+      volvol=volvol,
+      rho=rho,
+      strikes=strikes,
+      expiries=expiries,
+      spots=spots,
+      sampling_times=sampling_times,
+      discount_rates=discount_rates,
+      dividend_rates=dividend_rates
+    )
+
+    self.assertAllClose(expected_prices, computed_prices, 1e-2)
+
+  def test_single_sample_asian_matches_vanilla(self):
+    """Tests that a single sampling asian replicates vanilla prices."""
+    T = 1.0
+
+    variances = tf.constant([0.09, 0.09, 0.09])
+    mean_reversion = tf.constant([1.15, 1.15, 1.15])
+    volvol = tf.constant([0.39, 0.39, 0.39])
+    theta = tf.constant([0.0348, 0.0348, 0.0348])
+    rho = tf.constant([-0.64, -0.64, -0.64])
+    spots = tf.constant([100.0, 100.0, 100.0])
+    strikes = tf.constant([90.0, 100.0, 110.0])
+    discount_rates = tf.constant([0.05, 0.05, 0.05])
+    dividend_rates = tf.constant([0.0, 0.0, 0.0])
+
+    t_n = tf.constant([T], dtype=np.float32)
+    expiries = tf.constant([T, T, T])
+    sampling_times = tf.ones(shape=t_n.shape + spots.shape) * tf.expand_dims(t_n, 1)
+
+    computed_prices_asians = asian_option_price(
+      variances=variances,
+      mean_reversion=mean_reversion,
+      theta=theta,
+      volvol=volvol,
+      rho=rho,
+      strikes=strikes,
+      expiries=expiries,
+      spots=spots,
+      sampling_times=sampling_times,
+      discount_rates=discount_rates,
+      dividend_rates=dividend_rates
+    )
+
+    computed_price_europeans = european_option_price(
+      strikes=strikes,
+      expiries=expiries,
+      spots=spots,
+      discount_rates=discount_rates,
+      dividend_rates=dividend_rates,
+      variances=variances,
+      mean_reversion=mean_reversion,
+      theta=theta,
+      volvol=volvol,
+      rho=rho
+    )
+
+    self.assertAllClose(
+      computed_prices_asians,
+      computed_price_europeans,
+      1e-4
+    )
+
+  def test_option_prices_scalar_prices(self):
+    """Tests for methods for the asian pricing module with scalar inputs.
+    Expected results come from tables (1)-(3) in 'A Recursive Method for
+    Discretely Monitored Geometric Asian Option Prices', Bull. Korean Math.
+    Soc. 53, 733-749 (2016) by B. Kim, J. Kim, J. Kim & I. S. Wee (6m expiry,
+    daily sampling)
+    """
+    variances = 0.09
+    mean_reversion = 1.15
+    volvol = 0.39
+    theta = 0.0348
+    rho = -0.64
+    spots = 100.0
+    strikes = [90.0, 100.0, 110.0]
+
+    discount_rates = 0.05
+    dividend_rates = 0.0
+
+    T = 0.5
+    expiries = T
+    sampling_times = np.linspace(1/365, T, 182)[:, np.newaxis]
+
+    expected_prices = tf.constant([11.8924, 5.0910, 1.3597], dtype=np.float32)
+
+    computed_prices = asian_option_price(
+      variances=variances,
+      mean_reversion=mean_reversion,
+      theta=theta,
+      volvol=volvol,
+      rho=rho,
+      strikes=strikes,
+      expiries=expiries,
+      spots=spots,
+      sampling_times=sampling_times,
+      discount_rates=discount_rates,
+      dividend_rates=dividend_rates
+    )
+
+    self.assertAllClose(expected_prices, computed_prices, 1e-2)
+
+  def test_seasoned_analytic_vs_monte_carlo(self):
+    """Tests for methods for the asian pricing module a seasoned asian option.
+    Results are compared to a Monte Carlo simulation.
+    """
+    variances = 0.09
+    mean_reversion = 1.15
+    volvol = 0.39
+    theta = 0.0348
+    rho = -0.64
+    spots = 100.0
+    strikes = [90.0, 100.0, 110.0]
+    discount_rates = 0.0
+
+    T = 1.0
+    expiries = T
+    sampling_times = np.linspace(0.25, T, 4)[:, np.newaxis]
+    past_fixings = [100.0, 100.0, 100.0]
+
+    computed_prices_asians = asian_option_price(
+      variances=variances,
+      mean_reversion=mean_reversion,
+      theta=theta,
+      volvol=volvol,
+      rho=rho,
+      strikes=strikes,
+      expiries=expiries,
+      spots=spots,
+      sampling_times=sampling_times,
+      discount_rates=discount_rates,
+      past_fixings=past_fixings
+    )
+
+    dtype = np.float64
+    num_samples = 100000
+    num_timesteps = 24
+
+    dt = 1. / num_timesteps
+    strikes_tensor = tf.constant(strikes, dtype=dtype)
+    times = tf.constant(np.linspace(0.25, T, 4), dtype=dtype)
+    log_spot = np.log(spots)
+
+    total_fixings = len(past_fixings) + times.shape[0]
+    running_accumulator = np.prod(past_fixings)
+
+    process = HestonModel(
+      mean_reversion=mean_reversion,
+      theta=theta,
+      volvol=volvol,
+      rho=rho,
+      dtype=dtype
+    )
+
+    initial_state = tf.constant([log_spot, variances], dtype=dtype)
+    paths = process.sample_paths(
+      times,
+      initial_state,
+      time_step=dt,
+      num_samples=num_samples,
+      seed=123
+    )
+
+    prefactor = running_accumulator ** (1 / total_fixings)
+    spot_prods = prefactor * tf.math.exp(tf.reduce_sum(paths[:,:,0], 1)
+                                         / total_fixings)
+    spot_prods = tf.broadcast_to(tf.expand_dims(spot_prods, 1),
+                                 spot_prods.shape + strikes_tensor.shape)
+    payoffs = tf.nn.relu(spot_prods - strikes_tensor)
+    mc_prices = tf.math.reduce_mean(payoffs, 0)
+
+    self.assertAllClose(computed_prices_asians, mc_prices, 1e-2)
+
+  def test_puts_and_calls_match_vanilla(self):
+    """Tests that single sampling puts and calls both match vanilla prices."""
+
+    variances = 0.09
+    mean_reversion = 1.15
+    volvol = 0.39
+    theta = 0.0348
+    rho = -0.64
+    spots = 100.0
+    strikes = [90.0, 100.0, 110.0]
+    discount_rates = 0.05
+    dividend_rates = 0.0
+
+    is_call_options = [False, True, False]
+
+    T = 1.0
+
+    t_n = tf.constant([1.0], dtype=np.float32)
+    expiries = tf.constant([T, T, T])
+    sampling_times = tf.constant([1.0, 1.0, 1.0])[:, np.newaxis]
+
+    computed_prices_asians = asian_option_price(
+      variances=variances,
+      mean_reversion=mean_reversion,
+      theta=theta,
+      volvol=volvol,
+      rho=rho,
+      strikes=strikes,
+      expiries=expiries,
+      spots=spots,
+      sampling_times=sampling_times,
+      discount_rates=discount_rates,
+      dividend_rates=dividend_rates,
+      is_call_options=is_call_options
+    )
+
+    computed_price_europeans = european_option_price(
+      strikes=strikes,
+      expiries=expiries,
+      spots=spots,
+      discount_rates=discount_rates,
+      dividend_rates=dividend_rates,
+      variances=variances,
+      mean_reversion=mean_reversion,
+      theta=theta,
+      volvol=volvol,
+      rho=rho,
+      is_call_options=is_call_options
+    )
+
+    self.assertAllClose(
+      computed_prices_asians,
+      computed_price_europeans,
+      1e-4
+    )
+
+if __name__ == '__main__':
+  tf.test.main()


### PR DESCRIPTION
Pricing discrete geometric asians under Heston volatility, using the method described by B. Kim, J. Kim, J. Kim & I. S. Wee in "A Recursive Method for Discretely Monitored Geometric Asian Option Prices"