### PR TITLE
Default constructor no longer available

### DIFF
--- a/tf_quant_finance/examples/jupyter_notebooks/American_Option_Black_Scholes.ipynb
+++ b/tf_quant_finance/examples/jupyter_notebooks/American_Option_Black_Scholes.ipynb
@@ -797,7 +797,7 @@
         "\n",
         "calculation_date = ql.Date(1, 1, 2010)\n",
         "maturity_date = ql.Date(1, 1, 2011)\n",
-        "day_count = ql.Thirty360()\n",
+        "day_count = ql.Thirty360(ql.Thirty360.BondBasis)\n",
         "calendar = ql.NullCalendar()\n",
         "\n",
         "option_type = ql.Option.Call\n",

--- a/tf_quant_finance/examples/jupyter_notebooks/Monte_Carlo_Euler_Scheme.ipynb
+++ b/tf_quant_finance/examples/jupyter_notebooks/Monte_Carlo_Euler_Scheme.ipynb
@@ -448,7 +448,7 @@
         "\n",
         "calculation_date = ql.Date(1, 1, 2010)\n",
         "maturity_date = ql.Date(1, 1, 2011)\n",
-        "day_count = ql.Thirty360()\n",
+        "day_count = ql.Thirty360(ql.Thirty360.BondBasis)\n",
         "calendar = ql.NullCalendar()\n",
         "\n",
         "ql_strike_price = 550\n",


### PR DESCRIPTION
As of QuantLib 1.28 the default constructor when calling `ql.Thirty360()` is no longer available in the underlying C++ library, and so a `BondBasis` must be supplied. Otherwise a `TypeError` will be thrown when executing these notebook cells:

```
TypeError                                 Traceback (most recent call last)
[<ipython-input-17-0acd484f2084>](https://localhost:8080/#) in <module>
     35 calculation_date = ql.Date(1, 1, 2010)
     36 maturity_date = ql.Date(1, 1, 2011)
---> 37 day_count = ql.Thirty360()
     38 calendar = ql.NullCalendar()
     39 

[/usr/local/lib/python3.8/dist-packages/QuantLib/QuantLib.py](https://localhost:8080/#) in __init__(self, *args)
   3479 
   3480     def __init__(self, *args):
-> 3481         _QuantLib.Thirty360_swiginit(self, _QuantLib.new_Thirty360(*args))
   3482     __swig_destroy__ = _QuantLib.delete_Thirty360
   3483 

TypeError: Wrong number or type of arguments for overloaded function 'new_Thirty360'.
  Possible C/C++ prototypes are:
    QuantLib::Thirty360::Thirty360(QuantLib::Thirty360::Convention,Date const &)
    QuantLib::Thirty360::Thirty360(QuantLib::Thirty360::Convention)
```

For details see: https://stackoverflow.com/a/74336038/1773216