### PR TITLE
fix(sec): upgrade numpy to 1.22.2

### DIFF
--- a/tf_quant_finance/examples/demos/option_pricing_basic/pricer/requirements.txt
+++ b/tf_quant_finance/examples/demos/option_pricing_basic/pricer/requirements.txt
@@ -1,6 +1,6 @@
 absl-py==0.9.0
 pyzmq==19.0.0
-numpy==1.22.0
+numpy==1.22.2
 tf-nightly
 tfp-nightly
 tff-nightly


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in numpy 1.22.0
- [CVE-2021-34141](https://www.oscs1024.com/hd/CVE-2021-34141)


### What did I do？
Upgrade numpy from 1.22.0 to 1.22.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS