### PR TITLE
Replace MD5 with SHA-256 in hasher function

### DIFF
--- a/tf_quant_finance/experimental/pricing_platform/framework/utils.py
+++ b/tf_quant_finance/experimental/pricing_platform/framework/utils.py
@@ -19,5 +19,5 @@ import json
 
 def hasher(obj):
   """Returns non-cryptographic hash of a JSON-serializable object."""
-  h = hashlib.md5(json.dumps(obj).encode())
+  h = hashlib.sha256(json.dumps(obj).encode())
   return h.hexdigest()


### PR DESCRIPTION
Fixes #109.

Replaces `hashlib.md5` with `hashlib.sha256` in `utils.hasher()`. The function is used for cache keying in the pricing platform, so switching algorithms is a drop-in change with no downstream breakage.