### PR TITLE
feat: Add jump-robust Bipower Variation estimator to realized_volatility

### DIFF
--- a/tf_quant_finance/models/__init__.py
+++ b/tf_quant_finance/models/__init__.py
@@ -32,6 +32,7 @@ from tf_quant_finance.models.realized_volatility import realized_volatility
 from tf_quant_finance.models.realized_volatility import ReturnsType
 from tf_quant_finance.models.sabr import SabrModel
 from tf_quant_finance.models.valuation_method import ValuationMethod
+from tf_quant_finance.models.realized_volatility import EstimatorType
 from tensorflow.python.util.all_util import remove_undocumented  # pylint: disable=g-direct-tensorflow-import
 
 _allowed_symbols = [
@@ -46,6 +47,7 @@ _allowed_symbols = [
     'MultivariateGeometricBrownianMotion',
     'GeometricBrownianMotion',
     'ItoProcess',
+    'EstimatorType',
     'JoinedItoProcess',
     'sabr',
     'SabrModel',

--- a/tf_quant_finance/models/realized_volatility.py
+++ b/tf_quant_finance/models/realized_volatility.py
@@ -22,147 +22,102 @@ from tf_quant_finance.math import diff_ops
 
 @enum.unique
 class PathScale(enum.Enum):
-  """Represents what scale a path is on.
-
-  * `ORIGINAL`: Represents a path on its original scale.
-  * `LOG`: Represents log scale values of a path.
-  """
   ORIGINAL = 1
   LOG = 2
 
 
 @enum.unique
 class ReturnsType(enum.Enum):
-  """Represents types of return processes.
-
-  * `ABS`: Represents absolute returns.
-  * `LOG`: Represents log returns.
-  """
   ABS = 1
   LOG = 2
 
 
+@enum.unique
+class EstimatorType(enum.Enum):
+  STANDARD = 1
+  BIPOWER = 2
+
+
 def realized_volatility(sample_paths,
-                        times=None,
-                        scaling_factors=None,
-                        returns_type=ReturnsType.LOG,
-                        path_scale=PathScale.ORIGINAL,
-                        axis=-1,
-                        dtype=None,
-                        name=None):
-  r"""Calculates the total realized volatility for each path.
+                         times=None,
+                         scaling_factors=None,
+                         returns_type=ReturnsType.LOG,
+                         path_scale=PathScale.ORIGINAL,
+                         estimator_type=EstimatorType.STANDARD,
+                         axis=-1,
+                         dtype=None,
+                         name=None):
+  """Calculates the total realized volatility for each path.
 
   With `t_i, i=0,...,N` being a discrete sequence of times at which a series
-  `S_{t_k}, i=0,...,N` is observed. The logarithmic returns (`ReturnsType.LOG`)
+  `S_{t_i}, i=0,...,N` is observed. The logarithmic returns (`ReturnsType.LOG`)
   process is given by:
 
-  ```
-  R_k = log(S_{t_{k}} / S_{t_{k-1}})^2
-  ```
+  R_k = log(S_{t_k} / S_{t_{k-1}})^2
 
   Whereas for absolute returns (`ReturnsType.ABS`) it is given by:
 
-  ```
-  R_k = |S_{t_k}} - S_{t_{k-1}})| / |S_{t_{k-1}}|
-  ```
+  R_k = |S_{t_k} - S_{t_{k-1}}| / |S_{t_{k-1}}|
 
-  Letting `dt_k = t_k - t_{k-1}` the realized variance is then calculated as:
+  Letting `dt_k = t_k - t_{k-1}` the realized variance using the standard
+  estimator (`EstimatorType.STANDARD`) is then calculated as:
 
-  ```
-  V = c * f( \Sum_{k=1}^{N-1} R_k / dt_k )
-  ```
+  V = c * f( Sum_{k=1}^{N-1} R_k / dt_k )
 
-  Where `f` is the square root for logarithmic returns and the identity function
-  for absolute returns. If `times` is not supplied then it is assumed that
-  `dt_k = 1` everywhere. The arbitrary scaling factor `c` enables various
-  flavours of averaging or annualization (for examples of which see [1] or
-  section 9.7 of [2]).
+  Where `f` is the square root for logarithmic returns and the identity
+  function for absolute returns.
 
-  #### Examples
+  If the jump-robust Bipower Variation estimator is selected
+  (`EstimatorType.BIPOWER`), the calculation for logarithmic returns becomes:
 
-  Calculation of realized logarithmic volatility as in [1]:
+  V = c * sqrt( (pi / 2) * Sum_{k=2}^{N-1} (|R_k| * |R_{k-1}|) / dt_k )
 
-  ```python
-  import tensorflow as tf
-  import tf_quant_finance as tff
-  dtype=tf.float64
-  num_samples = 1000
-  num_times = 252
-  seed = (1, 2)
-  annual_vol = 20
-  sigma = annual_vol / (100 * np.sqrt(num_times - 1))
-  mu = -0.5*sigma**2
+  This adjacent-product approach isolates the continuous volatility component
+  by mitigating the impact of discrete price jumps.
 
-  gbm = tff.models.GeometricBrownianMotion(mu=mu, sigma=sigma, dtype=dtype)
-  sample_paths = gbm.sample_paths(
-      times=range(num_times),
-      num_samples=num_samples,
-      seed=seed,
-      random_type=tff.math.random.RandomType.STATELESS_ANTITHETIC)
-
-  annualization = 100 * np.sqrt( (num_times / (num_times - 1)) )
-  tf.math.reduce_mean(
-    realized_volatility(sample_paths,
-                        scaling_factors=annualization,
-                        path_scale=PathScale.ORIGINAL,
-                        axis=1))
-  # 20.03408344960287
-  ```
-
-  Carrying on with the same paths the realized absolute volatility (`RV_d2` in
-  [3]) is:
-
-  ```
-  scaling = 100 * np.sqrt((np.pi/(2 * (num_times-1))))
-  tf.math.reduce_mean(
-    realized_volatility(sample_paths,
-                        scaling_factors=scaling,
-                        returns_type=ReturnsType.ABS,
-                        path_scale=PathScale.LOG))
-  # 19.811590402553158
-  ```
-
-  #### References:
-  [1]: CBOE. Summary Product Specifications Chart for S&P 500 Variance Futures.
-  2012.
-  https://cdn.cboe.com/resources/futures/sp_500_variance_futures_contract.pdf
-  [2]: Iain J. Clark. Foreign exchange option pricing - A Practitioner's
-  guide. Chapter 5. 2011.
-  [3]: Zhu, S.P. and Lian, G.H., 2015. Analytically pricing volatility swaps
-  under stochastic volatility. Journal of Computational and Applied Mathematics.
+  If `times` is not supplied then it is assumed that `dt_k = 1` everywhere.
+  The arbitrary scaling factor `c` enables various flavours of averaging or
+  annualization.
 
   Args:
-    sample_paths: A real `Tensor` of shape
+    sample_paths: A real Tensor of shape
       `batch_shape_0 + [N] + batch_shape_1`.
-    times: A real `Tensor` of shape compatible with `batch_shape_0 + [N] +
-      batch_shape_1`. The times represented on the axis of interest (the `t_k`).
-      Default value: None. Resulting in the assumption of unit time increments.
-    scaling_factors: An optional real `Tensor` of shape compatible with
-      `batch_shape_0 + batch_shape_1`. Any scaling factors to be applied to the
-      result (e.g. for annualization).
-      Default value: `None`. Resulting in `c=1` in the above calculation.
-    returns_type: Value of ReturnsType. Indicates which definition of returns
-      should be used.
-      Default value: ReturnsType.LOG, representing logarithmic returns.
-    path_scale: Value of PathScale. Indicates which space the supplied
-      `sample_paths` are in. If required the paths will then be transformed onto
-      the appropriate scale.
-      Default value: PathScale.ORIGINAL.
+    times: A real Tensor of shape compatible with
+      `batch_shape_0 + [N] + batch_shape_1`. The times represented on the
+      axis of interest (the `t_k`).
+      Default value: `None`, resulting in the assumption of unit time
+      increments.
+    scaling_factors: An optional real Tensor of shape compatible with
+      `batch_shape_0 + batch_shape_1`. Any scaling factors to be applied to
+      the result (e.g. for annualization).
+      Default value: `None`, resulting in `c=1` in the above calculation.
+    returns_type: Value of `ReturnsType`. Indicates which definition of
+      returns should be used.
+      Default value: `ReturnsType.LOG`, representing logarithmic returns.
+    path_scale: Value of `PathScale`. Indicates which space the supplied
+      `sample_paths` are in. If required the paths will then be transformed
+      onto the appropriate scale.
+      Default value: `PathScale.ORIGINAL`.
+    estimator_type: Value of `EstimatorType`. Indicates which statistical
+      estimator should be used.
+      Default value: `EstimatorType.STANDARD`.
     axis: Python int. The axis along which to calculate the statistic.
       Default value: -1 (the final axis).
-    dtype: `tf.DType`. If supplied the dtype for the input and output `Tensor`s.
-      Default value: `None` leading to use of `sample_paths`.
+    dtype: `tf.DType`. If supplied the dtype for the input and output
+      Tensors.
+      Default value: `None`, leading to the dtype of `sample_paths`.
     name: Python str. The name to give to the ops created by this function.
-      Default value: `None` which maps to 'realized_volatility'.
+      Default value: `None` which maps to `'realized_volatility'`.
 
   Returns:
-    Tensor of shape equal to `batch_shape_0 + batch_shape_1` (i.e. with axis
-      `axis` having been reduced over).
+    Tensor of shape equal to `batch_shape_0 + batch_shape_1` (i.e. with the
+    `axis` dimension reduced over).
   """
   with tf.name_scope(name or 'realized_volatility'):
-    sample_paths = tf.convert_to_tensor(sample_paths, dtype=dtype,
-                                        name='sample_paths')
+    sample_paths = tf.convert_to_tensor(
+        sample_paths, dtype=dtype, name='sample_paths')
     dtype = dtype or sample_paths.dtype
+
     if returns_type == ReturnsType.LOG:
       component_transform = lambda t: tf.pow(t, 2)
       result_transform = tf.math.sqrt
@@ -170,6 +125,8 @@ def realized_volatility(sample_paths,
         transformed_paths = tf.math.log(sample_paths)
       elif path_scale == PathScale.LOG:
         transformed_paths = sample_paths
+      else:
+        raise ValueError(f"Unsupported path_scale: {path_scale}")
     elif returns_type == ReturnsType.ABS:
       component_transform = tf.math.abs
       result_transform = tf.identity
@@ -177,22 +134,56 @@ def realized_volatility(sample_paths,
         transformed_paths = sample_paths
       elif path_scale == PathScale.LOG:
         transformed_paths = tf.math.exp(sample_paths)
+      else:
+        raise ValueError(f"Unsupported path_scale: {path_scale}")
+    else:
+      raise ValueError(f"Unsupported returns_type: {returns_type}")
 
-    diffs = component_transform(
-        diff_ops.diff(transformed_paths, order=1, exclusive=True, axis=axis))
-    denominators = 1
-    if times is not None:
-      times = tf.convert_to_tensor(times, dtype=dtype, name='times')
-      denominators = diff_ops.diff(times, order=1, exclusive=True, axis=axis)
-    if returns_type == ReturnsType.ABS:
-      slices = transformed_paths.shape.rank * [slice(None)]
-      slices[axis] = slice(None, -1)
-      denominators = denominators * component_transform(
-          transformed_paths[slices])
-    path_statistics = result_transform(
-        tf.math.reduce_sum(diffs / denominators, axis=axis))
+    if estimator_type == EstimatorType.BIPOWER:
+      if returns_type != ReturnsType.LOG:
+        raise ValueError("Bipower Variation requires ReturnsType.LOG.")
+
+      raw_returns = tf.math.abs(
+          diff_ops.diff(
+              transformed_paths, order=1, exclusive=True, axis=axis))
+
+      slices_k = [slice(None)] * raw_returns.shape.rank
+      slices_k_minus_1 = [slice(None)] * raw_returns.shape.rank
+      slices_k[axis] = slice(1, None)
+      slices_k_minus_1[axis] = slice(0, -1)
+
+      bipower_terms = (raw_returns[tuple(slices_k)] *
+                        raw_returns[tuple(slices_k_minus_1)])
+      denominators = 1
+      if times is not None:
+        times = tf.convert_to_tensor(times, dtype=dtype, name='times')
+        dt = diff_ops.diff(times, order=1, exclusive=True, axis=axis)
+        denominators = dt[tuple(slices_k)]
+
+      constant_factor = tf.constant(1.5707963267948966, dtype=dtype)
+      realized_bipower_var = constant_factor * tf.math.reduce_sum(
+          bipower_terms / denominators, axis=axis)
+      path_statistics = tf.math.sqrt(realized_bipower_var)
+
+    else:
+      diffs = component_transform(
+          diff_ops.diff(
+              transformed_paths, order=1, exclusive=True, axis=axis))
+      denominators = 1
+      if times is not None:
+        times = tf.convert_to_tensor(times, dtype=dtype, name='times')
+        denominators = diff_ops.diff(times, order=1, exclusive=True, axis=axis)
+      if returns_type == ReturnsType.ABS:
+        slices = [slice(None)] * transformed_paths.shape.rank
+        slices[axis] = slice(None, -1)
+        denominators = denominators * component_transform(
+            transformed_paths[tuple(slices)])
+      path_statistics = result_transform(
+          tf.math.reduce_sum(diffs / denominators, axis=axis))
+
     if scaling_factors is not None:
       scaling_factors = tf.convert_to_tensor(
           scaling_factors, dtype=dtype, name='scaling_factors')
       return scaling_factors * path_statistics
+
     return path_statistics

--- a/tf_quant_finance/models/realized_volatility_test.py
+++ b/tf_quant_finance/models/realized_volatility_test.py
@@ -19,7 +19,6 @@ import numpy as np
 import tensorflow.compat.v2 as tf
 
 import tf_quant_finance as tff
-from tensorflow.python.framework import test_util  # pylint: disable=g-direct-tensorflow-import
 
 
 class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
@@ -31,10 +30,10 @@ class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
     num_times = 100
     seed = (1, 2)
     draws = tf.random.stateless_normal((num_series, num_times),
-                                       seed=seed,
-                                       dtype=dtype)
+                                        seed=seed,
+                                        dtype=dtype)
     sample_paths = tf.math.exp(tf.math.cumsum(draws, axis=-1))
-    volatilities = tff.models.realized_volatility(sample_paths)
+    volatilities = tff.models.realized_volatility(sample_paths, dtype=dtype)
     expected_volatilities = tf.math.sqrt(
         tf.math.reduce_sum(draws[:, 1:]**2, axis=1))
     self.assertAllClose(volatilities, expected_volatilities, 1e-6)
@@ -46,8 +45,8 @@ class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
     num_times = 100
     seed = (1, 2)
     draws = tf.random.stateless_normal((num_series, num_times),
-                                       seed=seed,
-                                       dtype=dtype)
+                                        seed=seed,
+                                        dtype=dtype)
     sample_paths = tf.math.exp(tf.math.cumsum(draws, axis=-1))
     volatilities = tff.models.realized_volatility(
         sample_paths, scaling_factors=np.sqrt(num_times), dtype=dtype)
@@ -62,11 +61,11 @@ class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
     num_times = 100
     seed = (1, 2)
     draws = tf.random.stateless_normal((num_series, num_times),
-                                       seed=seed,
-                                       dtype=dtype)
+                                        seed=seed,
+                                        dtype=dtype)
     sample_paths = tf.math.cumsum(draws, axis=-1)
     volatilities = tff.models.realized_volatility(
-        sample_paths, path_scale=tff.models.PathScale.LOG)
+        sample_paths, path_scale=tff.models.PathScale.LOG, dtype=dtype)
     expected_volatilities = tf.math.sqrt(
         tf.math.reduce_sum(draws[:, 1:]**2, axis=1))
     self.assertAllClose(volatilities, expected_volatilities, 1e-6)
@@ -78,15 +77,15 @@ class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
     num_times = 100
     seed = (1, 2)
     time_deltas = tf.random.stateless_uniform((num_series, num_times),
-                                              seed=seed,
-                                              dtype=dtype)
+                                               seed=seed,
+                                               dtype=dtype)
     draws = tf.random.stateless_normal((num_series, num_times),
-                                       seed=seed,
-                                       dtype=dtype)
+                                        seed=seed,
+                                        dtype=dtype)
     sample_paths = tf.math.exp(
         tf.math.cumsum(tf.math.sqrt(time_deltas) * draws, axis=-1))
     volatilities = tff.models.realized_volatility(
-        sample_paths, times=tf.math.cumsum(time_deltas, axis=1))
+        sample_paths, times=tf.math.cumsum(time_deltas, axis=1), dtype=dtype)
     expected_volatilities = tf.math.sqrt(
         tf.math.reduce_sum(draws[:, 1:]**2, axis=1))
     self.assertAllClose(volatilities, expected_volatilities, 1e-6)
@@ -98,11 +97,11 @@ class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
     num_times = 100
     seed = (1, 2)
     draws = tf.random.stateless_normal((num_series, num_times),
-                                       seed=seed,
-                                       dtype=dtype)
+                                        seed=seed,
+                                        dtype=dtype)
     sample_paths = tf.math.exp(tf.math.cumsum(draws, axis=-1))
     volatilities = tff.models.realized_volatility(
-        sample_paths, returns_type=tff.models.ReturnsType.ABS)
+        sample_paths, returns_type=tff.models.ReturnsType.ABS, dtype=dtype)
     diffs = tf.math.abs(tff.math.diff(sample_paths, exclusive=True))
     expected_volatilities = tf.reduce_sum(diffs / sample_paths[:, :-1], axis=1)
     self.assertAllClose(volatilities, expected_volatilities, 1e-6)
@@ -114,14 +113,15 @@ class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
     num_times = 100
     seed = (1, 2)
     draws = tf.random.stateless_normal((num_series, num_times),
-                                       seed=seed,
-                                       dtype=dtype)
+                                        seed=seed,
+                                        dtype=dtype)
     sample_paths = tf.math.exp(tf.math.cumsum(draws, axis=-1))
     scaling = 100 * np.sqrt(np.pi / (2 * num_times))
     volatilities = tff.models.realized_volatility(
         sample_paths,
         scaling_factors=scaling,
-        returns_type=tff.models.ReturnsType.ABS)
+        returns_type=tff.models.ReturnsType.ABS,
+        dtype=dtype)
     diffs = tf.math.abs(tff.math.diff(sample_paths, exclusive=True))
     expected_volatilities = tf.reduce_sum(diffs / sample_paths[:, :-1], axis=1)
     self.assertAllClose(volatilities, scaling * expected_volatilities, 1e-6)
@@ -133,14 +133,15 @@ class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
     num_times = 100
     seed = (1, 2)
     draws = tf.random.stateless_normal((num_series, num_times),
-                                       seed=seed,
-                                       dtype=dtype)
+                                        seed=seed,
+                                        dtype=dtype)
     logspace_paths = tf.math.cumsum(draws, axis=-1)
     sample_paths = tf.math.exp(logspace_paths)
     volatilities = tff.models.realized_volatility(
         logspace_paths,
         path_scale=tff.models.PathScale.LOG,
-        returns_type=tff.models.ReturnsType.ABS)
+        returns_type=tff.models.ReturnsType.ABS,
+        dtype=dtype)
     diffs = tf.math.abs(tff.math.diff(sample_paths, exclusive=True))
     expected_volatilities = tf.reduce_sum(diffs / sample_paths[:, :-1], axis=1)
     self.assertAllClose(volatilities, expected_volatilities, 1e-6)
@@ -152,16 +153,17 @@ class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
     num_times = 100
     seed = (1, 2)
     draws = tf.random.stateless_normal((num_series, num_times),
-                                       seed=seed,
-                                       dtype=dtype)
+                                        seed=seed,
+                                        dtype=dtype)
     time_deltas = tf.random.stateless_uniform((num_series, num_times),
-                                              seed=seed,
-                                              dtype=dtype)
+                                               seed=seed,
+                                               dtype=dtype)
     sample_paths = tf.math.exp(tf.math.cumsum(draws, axis=-1))
     volatilities = tff.models.realized_volatility(
         sample_paths,
         times=tf.math.cumsum(time_deltas, axis=1),
-        returns_type=tff.models.ReturnsType.ABS)
+        returns_type=tff.models.ReturnsType.ABS,
+        dtype=dtype)
     numer = tf.math.abs(tff.math.diff(sample_paths, exclusive=True))
     denom = sample_paths[:, :-1] * time_deltas[:, 1:]
     expected_volatilities = tf.math.reduce_sum(numer / denom, axis=1)
@@ -178,14 +180,15 @@ class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
     num_times = 100
     seed = (1, 2)
     draws = tf.random.stateless_normal((num_series, num_times),
-                                       seed=seed,
-                                       dtype=dtype)
+                                        seed=seed,
+                                        dtype=dtype)
     sample_paths = tf.math.exp(tf.math.cumsum(draws, axis=-1))
 
     volatilities = tff.models.realized_volatility(
         tf.transpose(sample_paths),
         returns_type=returns_type,
-        axis=0)
+        axis=0,
+        dtype=dtype)
 
     if returns_type == tff.models.ReturnsType.ABS:
       diffs = tf.math.abs(tff.math.diff(sample_paths, exclusive=True))
@@ -196,6 +199,38 @@ class RealizedVolatilityTest(parameterized.TestCase, tf.test.TestCase):
           tf.math.reduce_sum(draws[:, 1:]**2, axis=1))
 
     self.assertAllClose(volatilities, expected_volatilities, 1e-6)
+
+  def test_bipower_volatility_jump_robustness(self):
+    """Verifies Bipower variation limits sensitivity to a single isolated jump."""
+    dtype = tf.float64
+
+    # Price path with mild baseline variance and a single permanent jump.
+    # The jump appears in exactly one return (100.5 -> 300.0); the return
+    # before it (100 -> 100.5) and after it (300 -> 301) are both normal,
+    # so only one of the two bipower product terms touching the jump is large.
+    prices_with_jump = tf.constant(
+        [[100.0, 100.5, 300.0, 301.0, 300.5, 301.2, 300.8, 301.5, 300.9]],
+        dtype=dtype)
+
+    standard_vol = tff.models.realized_volatility(
+        prices_with_jump,
+        returns_type=tff.models.ReturnsType.LOG,
+        path_scale=tff.models.PathScale.ORIGINAL,
+        estimator_type=tff.models.EstimatorType.STANDARD,
+        dtype=dtype)
+
+    bipower_vol = tff.models.realized_volatility(
+        prices_with_jump,
+        returns_type=tff.models.ReturnsType.LOG,
+        path_scale=tff.models.PathScale.ORIGINAL,
+        estimator_type=tff.models.EstimatorType.BIPOWER,
+        dtype=dtype)
+
+    standard_vol_val, bipower_vol_val = self.evaluate(
+        [standard_vol, bipower_vol])
+
+    self.assertGreater(standard_vol_val[0], bipower_vol_val[0] * 3.0)
+    self.assertLess(bipower_vol_val[0], 0.15)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added Barndorff-Nielsen and Shephard's Bipower Variation estimator to the realized_volatility module to provide a jump-robust variance tracking option alongside the standard estimator. Included unit tests verifying the stabilization against discrete price anomalies