### PR TITLE
Pin protobuf to the generated-code compatible range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if release_suffix:
   __version__ += release_suffix
 
 REQUIRED_PACKAGES = [
-    'attrs >= 18.2.0', tfp_package, 'numpy >= 1.21', 'protobuf'
+    'attrs >= 18.2.0', tfp_package, 'numpy >= 1.21', 'protobuf >= 3.20.3, < 4.0.0'
 ]
 
 


### PR DESCRIPTION
Fixes #111.

The pip package currently leaves `protobuf` unbounded even though the generated `_pb2.py` files are not compatible with newer protobuf releases. That makes fresh installs on Colab and similar environments fail at import time with the direct-descriptor error.

This aligns the package metadata with the version range already used in CI by requiring `protobuf>=3.20.3,<4.0.0`.
